### PR TITLE
Fix: styles for tables in SQL lessons

### DIFF
--- a/css/swc.css
+++ b/css/swc.css
@@ -466,17 +466,31 @@ section.content {
     font-size: 40pt;
 }
 
-thead .header {
-    background: rgba(0, 0, 0, 0.15);
+table {
+    margin-bottom: 15px;
 }
 
 table th, table td {
-    padding: 5px;
+    padding: 5px 10px;
 }
 
-table {
-    border: 1px solid rgba(0, 0, 0, 0.15);
-    margin-bottom: 15px;
+table > thead > .header {
+    background: transparent;
+}
+
+table > thead > tr > td, table > thead > tr > th,
+table > tbody > tr > td, table > tbody > tr > th,
+table > tfoot > tr > td, table > tfoot > tr > th {
+    border: 1px solid #DDD;
+}
+
+table > thead > tr > th,
+table > thead > tr > td {
+    border-bottom-width: 2px;
+}
+
+table tbody > tr:nth-of-type(2n+1) {
+    background-color: #F9F9F9;
 }
 
 #header-text {

--- a/css/swc.css
+++ b/css/swc.css
@@ -466,6 +466,19 @@ section.content {
     font-size: 40pt;
 }
 
+thead .header {
+    background: rgba(0, 0, 0, 0.15);
+}
+
+table th, table td {
+    padding: 5px;
+}
+
+table {
+    border: 1px solid rgba(0, 0, 0, 0.15);
+    margin-bottom: 15px;
+}
+
 #header-text {
     font-size:20pt;
     margin:0;


### PR DESCRIPTION
This PR addresses #9.

### Previously

* table cells had no padding, which caused a visual collapse (cell content was too close to cell neighbors)
* table header rows had dark blue background and black letters
* tables had no space between them and following paragraphs.

BEFORE:
![screenshot from 2015-02-13 20 46 42](https://cloud.githubusercontent.com/assets/72821/6194287/4ce486c2-b3c3-11e4-8235-1322837291b3.png)

### Changes

* added 5px padding to cell contents
* changed header row background to gray-ish (I considered switching text color to white, but it didn't look good)
* 15px margin on the bottom of the tables (similarly to bottom margin used by paragraph style).

AFTER:
![screenshot from 2015-02-13 20 51 07](https://cloud.githubusercontent.com/assets/72821/6194298/72854cfe-b3c3-11e4-9b93-33c390c830b9.png)
