### PR TITLE
Fix background for lessons

### DIFF
--- a/css/swc.css
+++ b/css/swc.css
@@ -1,3 +1,8 @@
+/* Container */
+
+div.container {
+    background: white;
+}
 
 /* Headings */
 h1, h2, h3, h4, h5, h6 {
@@ -261,15 +266,6 @@ blockquote h2{
     color: rgb(0, 0, 0);
 }
 
-
-/* Container for page contents. */
-.container-full-width {
-	max-width: none;
-}
-
-.container .jumbotron {
-    padding: 20px;
-}
 
 code {
     color: #333333;


### PR DESCRIPTION
This solve the problem reported at https://github.com/swcarpentry/lesson-template/pull/200.

![lesson](https://cloud.githubusercontent.com/assets/1506457/6764239/b77709a0-cf85-11e4-9b74-32f2a68e11d6.jpg)

