### PR TITLE
CSS compatible with different versions of Pandoc

### DIFF
--- a/css/swc.css
+++ b/css/swc.css
@@ -57,6 +57,22 @@ class. */
     padding-right: 10px;
 }
 
+/* Make the CSS compatible with Pandoc <= 1.13.2 and Pandoc > 1.14. */
+h1.panel,
+h2.panel,
+h3.panel,
+h4.panel,
+h5.panel,
+h6.panel {
+    margin-top: 0px;
+    margin-bottom: 0px;
+    border: 0px;
+    color: inherit;
+    background-color: inherit;
+    background-image: inherit;
+    box-shadow: none;
+}
+
 /* Comments in code. */
 .comment {
     color: purple;


### PR DESCRIPTION
**The screenshots are with zoom of 150% to make easy to see the differences.**

With Pandoc <= 1.13.2:

![s-old](https://cloud.githubusercontent.com/assets/1506457/7220035/5dedf1b0-e690-11e4-94b3-f7219e83fade.jpg)

With Pandoc >= 1.14:

![s-new](https://cloud.githubusercontent.com/assets/1506457/7220030/179fc0ee-e690-11e4-887c-2f5b69e4d32f.jpg)

This pull request is a workaround to lessons have the same look of Pandoc <= 1.13.2 when built with Pandoc >= 1.14.
