### PR TITLE
Drop to collapsed menu to prevent the menu dissapearing behind the logo.

### DIFF
--- a/css/swc.css
+++ b/css/swc.css
@@ -733,7 +733,7 @@ div.chapter h2 {
 }
 
 /* Collapse navbar */
-@media (max-width: 993px) {
+@media (max-width: 1200px) {
     .navbar-header {
         float: none;
 	min-height: 80px;


### PR DESCRIPTION
replaces swcarpentry/site#1147.

Fixes this bug:

![screen shot 2015-10-29 at 15 03 33](https://cloud.githubusercontent.com/assets/1391051/10822708/34ea2e34-7e50-11e5-8cdd-daa7d485be53.png)
