### PR TITLE
use anonymous function to generate markdown files

### DIFF
--- a/bin/generate_md_episodes.R
+++ b/bin/generate_md_episodes.R
@@ -10,6 +10,6 @@ if (!require("stringr"))
 src_rmd <- list.files(pattern = "??-*.Rmd$", path = "_episodes_rmd", full.names = TRUE)
 dest_md <- file.path("_episodes", gsub("Rmd$", "md", basename(src_rmd)))
 
-for (i in seq_along(src_rmd)) {
-    knitr::knit(src_rmd[i], output = dest_md[i])
-}
+mapply(function(x, y) {
+        knitr::knit(x, output = y)
+    }, src_rmd, dest_md)


### PR DESCRIPTION
I had forgotten a little quirk of knitr that made the for loop fail. I'm using mapply with an anonymous function instead.