### PR TITLE
Only try building R files if there are some

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ HTML_DST = \
 
 ## lesson-rmd:    : convert Rmarkdown files to markdown
 lesson-rmd: $(RMD_SRC)
-	@bin/knit_lessons.sh
+	@bin/knit_lessons.sh $(RMD_SRC)
 
 ## lesson-check   : validate lesson Markdown.
 lesson-check :

--- a/bin/knit_lessons.sh
+++ b/bin/knit_lessons.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
-if [ -d "_episodes_rmd" ] ; then
+# Only try running R to translate files if there are some files present.
+# The Makefile passes in the names of files.
+
+if [ $# -ne 0 ] ; then
     Rscript -e "source('bin/generate_md_episodes.R')"
 fi


### PR DESCRIPTION
1.  Pass names of files to be built to `bin/knit_lessons.sh`.
2.  Only try to invoke `Rscript` if there are some files to knit.