### PR TITLE
stops awkward wrapping of code examples inside paragraphs

### DIFF
--- a/css/swc-print.css
+++ b/css/swc-print.css
@@ -37,6 +37,11 @@
     background: unset;
   }
 
+  /* don't wrap code samples inside paragraphs */
+  p > code {
+    white-space: nowrap;
+  }
+
   pre.sourceCode::before,
   pre.input::before. {
       content: "Input:";

--- a/css/swc.css
+++ b/css/swc.css
@@ -185,6 +185,11 @@ pre.error {
     color: Red;
 }
 
+/* don't wrap code samples inside paragraphs */
+p > code {
+    white-space: nowrap;
+}
+
 @media (max-width: 700px) {
     div.banner a img {
         padding: 20px 0px;


### PR DESCRIPTION
Applies a CSS fix to prevent the awkward wrapping of `<code>` examples inside `<p>`aragraphs.

This is the same fix discussed in [this lesson tamplate issue](https://github.com/swcarpentry/lesson-template/issues/296) and pull-req'ed against the lesson template repo, now being applied to the correct repo.