### PR TITLE
[fix # 82] Check R packages required by the lesson

### DIFF
--- a/bin/generate_md_episodes.R
+++ b/bin/generate_md_episodes.R
@@ -1,8 +1,7 @@
 generate_md_episodes <- function() {
 
-    if (require("knitr") && packageVersion("knitr") < '1.9.19') {
-            stop("knitr must be version 1.9.20 or higher")
-    } else stop("knitr 1.9.20 or above is needed to build the lessons.")
+    if (require("knitr") && packageVersion("knitr") < '1.9.19')
+        stop("knitr must be version 1.9.20 or higher")
 
     if (!require("stringr"))
         stop("The package stringr is required for generating the lessons.")

--- a/bin/generate_md_episodes.R
+++ b/bin/generate_md_episodes.R
@@ -1,13 +1,27 @@
 generate_md_episodes <- function() {
 
-    if (require("knitr")) {
-        if (packageVersion("knitr") < '1.9.19') {
+    if (require("knitr") && packageVersion("knitr") < '1.9.19') {
             stop("knitr must be version 1.9.20 or higher")
-        }
     } else stop("knitr 1.9.20 or above is needed to build the lessons.")
 
     if (!require("stringr"))
         stop("The package stringr is required for generating the lessons.")
+
+    if (require("checkpoint")) {
+        required_pkgs <-
+            checkpoint:::projectScanPackages(project = "_episodes_rmd",
+                                             verbose=FALSE, use.knitr = TRUE)$pkgs
+    } else {
+        stop("The checkpoint package is required to build the lessons.")
+    }
+
+    missing_pkgs <- required_pkgs[!(required_pkgs %in% rownames(installed.packages()))]
+
+    if (length(missing_pkgs)) {
+        message("Installing missing required packages: ",
+                paste(missing_pkgs, collapse=", "))
+        install.packages(missing_pkgs)
+    }
 
     ## find all the Rmd files, and generates the paths for their respective outputs
     src_rmd <- list.files(pattern = "??-*.Rmd$", path = "_episodes_rmd", full.names = TRUE)


### PR DESCRIPTION
Implements the solution proposed by @noamross to check that all the packages required to build the lessons are available, and if they are not they get installed.