### PR TITLE
Fix "br" typo causing ugly rendering (epub only)

### DIFF
--- a/_includes/episode_overview.html
+++ b/_includes/episode_overview.html
@@ -7,7 +7,7 @@
   <div class="row">
     <div class="col-md-3">
       <strong>Teaching:</strong> {{ page.teaching }} min
-      </br>
+      <br/>
       <strong>Exercises:</strong> {{ page.exercises }} min
     </div>
     <div class="col-md-9">


### PR DESCRIPTION
`</br>` instead of `<br/>` renders fine in the browser but not in an epub