### PR TITLE
accessibility fixes.

### DIFF
--- a/_includes/episode_navbar.html
+++ b/_includes/episode_navbar.html
@@ -1,6 +1,5 @@
 {% comment %}
   Find previous and next episodes (if any).
-  Including file must pass episode_navbar_title=true or ...=false to display episode title.
 {% endcomment %}
 {% for episode in site.episodes  %}
   {% if episode.url == page.url %}
@@ -21,9 +20,9 @@
   <div class="col-md-1">
     <h3>
       {% if prev_episode %}
-      <a href="{{ page.root }}{{ prev_episode.url }}"><span class="glyphicon glyphicon-menu-left"></span></a>
+      <a href="{{ page.root }}{{ prev_episode.url }}"><span class="glyphicon glyphicon-menu-left" aria-hidden="true"></span><span class="sr-only">previous episode</span></a>
       {% else %}
-      <a href="{{ page.root }}/"><span class="glyphicon glyphicon-menu-up"></span></a>
+      <a href="{{ page.root }}/"><span class="glyphicon glyphicon-menu-up" aria-hidden="true"></span><span class="sr-only">lesson home</span></a>
       {% endif %}
     </h3>
   </div>
@@ -36,9 +35,9 @@
   <div class="col-md-1">
     <h3>
       {% if next_episode %}
-      <a href="{{ page.root }}{{ next_episode.url }}"><span class="glyphicon glyphicon-menu-right"></span></a>
+      <a href="{{ page.root }}{{ next_episode.url }}"><span class="glyphicon glyphicon-menu-right" aria-hidden="true"></span><span class="sr-only">next episode</span></a>
       {% else %}
-      <a href="{{ page.root }}/"><span class="glyphicon glyphicon-menu-up"></span></a>
+      <a href="{{ page.root }}/"><span class="glyphicon glyphicon-menu-up" aria-hidden="true"></span><span class="sr-only">lesson home</span></a>
       {% endif %}
     </h3>
   </div>

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -68,7 +68,7 @@
       </ul>
       <form class="navbar-form navbar-right" role="search" id="search" onsubmit="google_search(); return false;">
         <div class="form-group">
-          <input type="text" id="google-search" placeholder="Search...">
+          <input type="text" id="google-search" placeholder="Search..." aria-label="Google site search">
         </div>
       </form>
     </div>


### PR DESCRIPTION
Add label to search box and episode navigation arrows.
This pull fixes two accessibility issues:

1. To ensure the google search box can be understood by screen readers, added `aria-label` to the `input`. 
2. The navigation arrows at the top and bottom of episode pages were flagged for accessibility issues because they don't have any text, just a glyphicon. They are `<h3>` and `<a>`, both of which need some text or alternative label so that a screen reader can make sense of their purpose.
I fixed it by adding `aria-hidden="true"` to the glyphicons and an alternative text using bootstrap `.sr-only` class to the Liquid generating the elements.

These fixes remove the major flags in accessibility audit software, but I have not tested it with actual screen reader or other accessibility software.
