### PR TITLE
fix search meta tag.

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -7,7 +7,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta http-equiv="last-modified" content="{{ site.time }}">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="search-domain" value="{{ page.root }}">
+    <!-- meta "search-domain" used for google site search function google_search() -->
+    <meta name="search-domain" value="{{ site.github.url }}">
     <link rel="stylesheet" type="text/css" href="{{ page.root }}/assets/css/bootstrap.css" />
     <link rel="stylesheet" type="text/css" href="{{ page.root }}/assets/css/bootstrap-theme.css" />
     <link rel="stylesheet" type="text/css" href="{{ page.root }}/assets/css/lesson.css" />


### PR DESCRIPTION
The google site search box is currently not working because the javascript looks for the repository url in a `meta` tag "search-domain" being filled by jekyll variable `page.root` which returns only `.`. With github pages the correct repository url can be called with the variable `site.github.url`. This results in a correct google search that includes the operator like `site:http://swcarpentry.github.io/lesson-example`