### PR TITLE
lesson.scss: 2em left padding for lists

### DIFF
--- a/assets/css/lesson.scss
+++ b/assets/css/lesson.scss
@@ -133,7 +133,7 @@ div.branding {
 
 ul,
 ol {
-  padding-left: 1em;
+  padding-left: 2em;
 }
 
 span.fold-unfold {


### PR DESCRIPTION
Example of the problem: see "Ten Things You Need To Know" from http://swcarpentry.github.io/lesson-example/

For numbered lists that have more that 9 elements 1 em padding on the left is not sufficient. The result is that "1" in numbers "10" and above is printed on top of the border of encapsulating HTML block. 2 em padding solves this problem for lists with less that 100 elements. It should be safe to assume that numbered lists in Carpentries' lessons should not have more than 99 items.

This PR is related to: #115 and swcarpentry/lesson-example#83 