### PR TITLE
Visually separate inline code blocks

### DIFF
--- a/assets/css/lesson.scss
+++ b/assets/css/lesson.scss
@@ -100,9 +100,9 @@ $codeblock-padding: 5px !default;
 //----------------------------------------
 
 code {
-  padding: 0 0;
-  color: inherit;
-  background-color: inherit;
+  padding: 2px 5px;
+  color: #3d90d9;
+  background-color: #e7e7e7;
 }
 
 img {


### PR DESCRIPTION
Change text color, background color and padding around inline code blocks.

### Before
![before](https://cloud.githubusercontent.com/assets/13123663/21193498/1fa674a6-c1f2-11e6-92e9-703215e5be70.png)

### After
![after](https://cloud.githubusercontent.com/assets/13123663/21193510/25c4c856-c1f2-11e6-9d4c-85a49cadeb56.png)