### PR TITLE
Knit episodes only when any one RMarkdown source changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ DST=_site
 
 # Controls
 .PHONY : commands clean files
+.NOTPARALLEL:
 all : commands
 
 ## commands         : show all commands.
@@ -16,11 +17,11 @@ commands :
 	@grep -h -E '^##' ${MAKEFILES} | sed -e 's/## //g'
 
 ## serve            : run a local server.
-serve : lesson-rmd
+serve : lesson-md
 	${JEKYLL} serve
 
 ## site             : build files but do not run a server.
-site : lesson-rmd
+site : lesson-md
 	${JEKYLL} build
 
 # repo-check        : check repository settings.
@@ -53,7 +54,7 @@ workshop-check :
 ## ----------------------------------------
 ## Commands specific to lesson websites.
 
-.PHONY : lesson-check lesson-rmd lesson-files lesson-fixme
+.PHONY : lesson-check lesson-md lesson-files lesson-fixme
 
 # RMarkdown files
 RMD_SRC = $(wildcard _episodes_rmd/??-*.Rmd)
@@ -79,9 +80,12 @@ HTML_DST = \
   $(patsubst _extras/%.md,${DST}/%/index.html,$(wildcard _extras/*.md)) \
   ${DST}/license/index.html
 
-## lesson-rmd       : convert Rmarkdown files to markdown
-lesson-rmd: $(RMD_SRC)
-	@bin/knit_lessons.sh $(RMD_SRC)
+## lesson-md        : convert Rmarkdown files to markdown
+lesson-md : ${RMD_DST}
+
+# Use of .NOTPARALLEL makes rule execute only once
+${RMD_DST} : ${RMD_SRC}
+	@bin/knit_lessons.sh ${RMD_SRC}
 
 ## lesson-check     : validate lesson Markdown.
 lesson-check :


### PR DESCRIPTION
The recipe for any phony target (e.g. `lesson-rmd`) will always run, so that's why bin/knit_lessons.sh was always executed as described in issue #91.

This PR introduces the logic that the Markdown files in `RMD_DST` are the prerequisites for a single `lesson-md` target, which is just a dummy grouping variable. The prerequisite for any one of RMD_DST is the original array of RMarkdown files (i.e. RMD_SRC). On systems that run make in parallel, the line `${RMD_DST} : ${RMD_SRC}` could cause bin/knit_lessons.sh to run for each member of RMD_DST. That would be bad, hence `.NOTPARALLEL`.
