### PR TITLE
bin/lesson_initialize.py: Remove 'example-site' reference

### DIFF
--- a/bin/lesson_initialize.py
+++ b/bin/lesson_initialize.py
@@ -158,7 +158,6 @@ You can also [reach us by email][contact].
 [dc-lessons]: http://datacarpentry.org/lessons/
 [dc-site]: http://datacarpentry.org/
 [discuss-list]: http://lists.software-carpentry.org/listinfo/discuss
-[example-site]: https://swcarpentry.github.io/lesson-example/
 [github]: http://github.com
 [github-flow]: https://guides.github.com/introduction/flow/
 [github-join]: https://github.com/join


### PR DESCRIPTION
The consumer was removed by 079d7d50 (#81).