### PR TITLE
ensure dt elements have an id set

### DIFF
--- a/_includes/javascript.html
+++ b/_includes/javascript.html
@@ -12,3 +12,16 @@
   ga('create', 'UA-37305346-2', 'auto');
   ga('send', 'pageview');
 </script>
+<script>
+  $('dt').each(function () {
+    if (!this.id) {
+      var id = $(this).text();
+      var index = id.indexOf('(');
+      if (index > 0) {
+        id = id.substring(0, index);
+      }
+      id = id.trim().replace(/ /g, '-').toLowerCase();
+      this.id = id;
+    }
+  });
+</script>

--- a/_includes/javascript.html
+++ b/_includes/javascript.html
@@ -13,13 +13,19 @@
   ga('send', 'pageview');
 </script>
 <script>
+  // This snippet fixes a bug caused by Github's pages-gem using kramdown v1.11.1.
+  // In order for anchor links to point to the correct place in the glossary, they must have an id
+  // This snippet ensures every definition term has an id
+  // See https://github.com/swcarpentry/styles/pull/129
   $('dt').each(function () {
     if (!this.id) {
       var id = $(this).text();
+      // If there's a ( in the name (e.g., "comma-separated values (CSV)") - just take everything up to the first (
       var index = id.indexOf('(');
       if (index > 0) {
         id = id.substring(0, index);
       }
+      // Strip leading and trailing whitespace, convert spaces to dashes and convert everything to lowercase
       id = id.trim().replace(/ /g, '-').toLowerCase();
       this.id = id;
     }


### PR DESCRIPTION
Anchor links in the glossary do not currently work in any of the lessons. As @gvwilson mentions in https://github.com/swcarpentry/python-novice-inflammation/issues/305, if Github updates their version of kramdown in pages-gem this issue would be resolved. However, it is unclear when this merge will occur - https://github.com/github/pages-gem/pull/398

This is a workaround for now, and can potentially be removed when the kramdown version is updated in pages-gem

This issue was also mentioned in https://github.com/swcarpentry/python-novice-inflammation/pull/315
