### PR TITLE
make sure that checkpoint version is 0.4.0 or higher

### DIFF
--- a/bin/generate_md_episodes.R
+++ b/bin/generate_md_episodes.R
@@ -6,12 +6,12 @@ generate_md_episodes <- function() {
     if (!require("stringr"))
         stop("The package stringr is required for generating the lessons.")
 
-    if (require("checkpoint")) {
+    if (require("checkpoint") && packageVersion("checkpoint") >=  '0.4.0') {
         required_pkgs <-
              checkpoint:::scanForPackages(project = "_episodes_rmd",
                                           verbose=FALSE, use.knitr = TRUE)$pkgs
     } else {
-        stop("The checkpoint package is required to build the lessons.")
+        stop("The checkpoint package (>= 0.4.0) is required to build the lessons.")
     }
 
     missing_pkgs <- required_pkgs[!(required_pkgs %in% rownames(installed.packages()))]


### PR DESCRIPTION
This is a follow up to #145, we ought to make sure that we are actually using the latest version of checkpoint before using the new name for the function.