### PR TITLE
Fix logo at navbar

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -12,15 +12,15 @@
       </button>
 
       {% comment %} Select what logo to display. {% endcomment %}
-      {% if page.carpentry == "swc" %}
+      {% if site.carpentry == "swc" %}
       <a href="{{ site.swc_site }}" class="pull-left">
         <img class="navbar-logo" src="{{ page.root }}/assets/img/swc-icon-blue.svg" alt="Software Carpentry logo" />
       </a>
-      {% elsif page.carpentry == "dc" %}
+      {% elsif site.carpentry == "dc" %}
       <a href="{{ site.dc_site }}" class="pull-left">
         <img class="navbar-logo" src="{{ page.root }}/assets/img/dc-icon-black.svg" alt="Data Carpentry logo" />
       </a>
-      {% elsif page.carpentry == "lc" %}
+      {% elsif site.carpentry == "lc" %}
       <a href="{{ site.lc_site }}" class="pull-left">
         <img class="navbar-logo" src="{{ page.root }}/assets/img/lc-icon-black.png" alt="Library Carpentry logo" />
       </a>


### PR DESCRIPTION
At https://github.com/swcarpentry/styles/issues/155#issuecomment-313035185, @drjwbaker said

> We appear to have lost the icon graphic from all our lessons

This pull request fix this issue.

@k8hertweck We need to patch the lessons with this pull request before the release. Sorry for it.

cc @mkuzak

