### PR TITLE
Output episode figures in correct order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,9 +65,9 @@ MARKDOWN_SRC = \
   index.md \
   CONDUCT.md \
   setup.md \
-  $(wildcard _episodes/*.md) \
+  $(sort $(wildcard _episodes/*.md)) \
   reference.md \
-  $(wildcard _extras/*.md) \
+  $(sort $(wildcard _extras/*.md)) \
   LICENSE.md
 
 # Generated lesson files in the order they appear in the navigation menu.

--- a/Makefile
+++ b/Makefile
@@ -75,9 +75,9 @@ HTML_DST = \
   ${DST}/index.html \
   ${DST}/conduct/index.html \
   ${DST}/setup/index.html \
-  $(patsubst _episodes/%.md,${DST}/%/index.html,$(wildcard _episodes/*.md)) \
+  $(patsubst _episodes/%.md,${DST}/%/index.html,$(sort $(wildcard _episodes/*.md))) \
   ${DST}/reference/index.html \
-  $(patsubst _extras/%.md,${DST}/%/index.html,$(wildcard _extras/*.md)) \
+  $(patsubst _extras/%.md,${DST}/%/index.html,$(sort $(wildcard _extras/*.md))) \
   ${DST}/license/index.html
 
 ## lesson-md        : convert Rmarkdown files to markdown


### PR DESCRIPTION
make lesson-figures was generating figures out of episode order.  This appears to be due to a change in GNU Make. In older versions this returned values from $(wildcard) in sorted order; it no longer does so.  See https://stackoverflow.com/questions/40558385/gnu-make-wildcard-no-longer-gives-sorted-output-is-there-any-control-switch

This PR sorts the output of $(wildcard) so that episode figures appear in the correct order.
