### PR TITLE
add keyboard key style

### DIFF
--- a/assets/css/lesson.scss
+++ b/assets/css/lesson.scss
@@ -153,3 +153,25 @@ span.fold-unfold {
   margin-left: 1em;
   opacity: 0.5;
 }
+
+
+//----------------------------------------
+// keyboard key style, from StackExchange.
+//----------------------------------------
+
+.keyboard {
+    display: inline-block;
+    margin: 0 .1em;
+    padding: .1em .6em;
+    font-family: Arial,"Helvetica Neue",Helvetica,sans-serif;
+    font-size: 11px;
+    line-height: 1.4;
+    color: #242729;
+    text-shadow: 0 1px 0 #FFF;
+    background-color: #e1e3e5;
+    border: 1px solid #adb3b9;
+    border-radius: 3px;
+    box-shadow: 0 1px 0 rgba(12,13,14,0.2), 0 0 0 2px #FFF inset;
+    white-space: nowrap;
+    font-style: normal;
+}

--- a/assets/css/lesson.scss
+++ b/assets/css/lesson.scss
@@ -159,7 +159,7 @@ span.fold-unfold {
 // keyboard key style, from StackExchange.
 //----------------------------------------
 
-.keyboard {
+kbd {
     display: inline-block;
     margin: 0 .1em;
     padding: .1em .6em;


### PR DESCRIPTION
Proposed usage:

<pre>when the user types a command and then presses *Enter*{:.keyboard} ...</pre>

The CSS is borrowed from StackExchange, which [implements this with the `<kbd>` tag][sx].

Block inline attribute lists are already used by SWC for e.g. the codeblocks, so I gather that this [span inline attribute list][sial] implementation is preferred over an HTML tag for SWC material.

SWC prefers verbose identifiers (`.objectives`, `.keypoints`, &etc), so I think `{:.keyboard}` would be preferred over `{:.kbd}`.

In practice it looks like this:

![keyboard-key-style](https://user-images.githubusercontent.com/2591290/29447372-6e0b60ea-83a6-11e7-86ff-97e5ef131ebe.png)

This would settle some confusion about how to format keyboard key names, such as swcarpentry/shell-novice#561.

[sx]: https://meta.stackexchange.com/questions/26207/how-can-i-format-as-keyboard-keys
[sial]: https://kramdown.gettalong.org/syntax.html#span-ials