### PR TITLE
Allows for fully-offline-capable functionality in lesson navigation.

### DIFF
--- a/_includes/all_keypoints.html
+++ b/_includes/all_keypoints.html
@@ -7,7 +7,7 @@
   {% unless episode.break %}
     <tr>
       <td class="col-md-3">
-        <a href="{{ page.root }}{{ episode.url }}">{{ episode.title }}</a>
+        <a href="{{ page.root }}{{ episode.url }}{{ site.index }}">{{ episode.title }}</a>
       </td>
       <td class="col-md-9">
         <ul>

--- a/_includes/episode_navbar.html
+++ b/_includes/episode_navbar.html
@@ -5,23 +5,23 @@
   <div class="col-md-1">
     <h3>
       {% if page.previous.url %}
-      <a href="{{ page.root }}{{ page.previous.url }}"><span class="glyphicon glyphicon-menu-left" aria-hidden="true"></span><span class="sr-only">previous episode</span></a>
+      <a href="{{ page.root }}{{ page.previous.url }}{{ site.index }}"><span class="glyphicon glyphicon-menu-left" aria-hidden="true"></span><span class="sr-only">previous episode</span></a>
       {% else %}
-      <a href="{{ page.root }}/"><span class="glyphicon glyphicon-menu-up" aria-hidden="true"></span><span class="sr-only">lesson home</span></a>
+      <a href="{{ page.root }}/{{ site.index }}"><span class="glyphicon glyphicon-menu-up" aria-hidden="true"></span><span class="sr-only">lesson home</span></a>
       {% endif %}
     </h3>
   </div>
   <div class="col-md-10">
     {% if include.episode_navbar_title %}
-    <h3 class="maintitle"><a href="{{ page.root }}/">{{ site.title }}</a></h3>
+    <h3 class="maintitle"><a href="{{ page.root }}/{{ site.index }}">{{ site.title }}</a></h3>
     {% endif %}
   </div>
   <div class="col-md-1">
     <h3>
       {% if page.next.url %}
-      <a href="{{ page.root }}{{ page.next.url }}"><span class="glyphicon glyphicon-menu-right" aria-hidden="true"></span><span class="sr-only">next episode</span></a>
+      <a href="{{ page.root }}{{ page.next.url }}{{ site.index }}"><span class="glyphicon glyphicon-menu-right" aria-hidden="true"></span><span class="sr-only">next episode</span></a>
       {% else %}
-      <a href="{{ page.root }}/"><span class="glyphicon glyphicon-menu-up" aria-hidden="true"></span><span class="sr-only">lesson home</span></a>
+      <a href="{{ page.root }}/{{ site.index }}"><span class="glyphicon glyphicon-menu-up" aria-hidden="true"></span><span class="sr-only">lesson home</span></a>
       {% endif %}
     </h3>
   </div>

--- a/_includes/main_title.html
+++ b/_includes/main_title.html
@@ -1,4 +1,4 @@
 {% comment %}
   Main title for lesson pages.
 {% endcomment %}
-<h1 class="maintitle"><a href="{{ page.root }}/">{{ site.title }}</a>{% if page.title %}: {{ page.title }}{% endif %}</h1>
+<h1 class="maintitle"><a href="{{ page.root }}/{{ site.index }}">{{ site.title }}</a>{% if page.title %}: {{ page.title }}{% endif %}</h1>

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -27,26 +27,26 @@
       {% endif %}
 
       {% comment %} Always show link to home page. {% endcomment %}
-      <a class="navbar-brand" href="{{ page.root }}/">Home</a>
+      <a class="navbar-brand" href="{{ page.root }}/{{ site.index }}">Home</a>
 
     </div>
     <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
       <ul class="nav navbar-nav">
 
 	{% comment %} Always show code of conduct. {% endcomment %}
-        <li><a href="{{ page.root }}/conduct/">Code of Conduct</a></li>
+        <li><a href="{{ page.root }}/conduct/{{ site.index }}">Code of Conduct</a></li>
 
 	{% comment %} Show setup instructions, reference guide, and lesson episodes for lessons. {% endcomment %}
         {% if site.kind == "lesson" %}
-        <li><a href="{{ page.root }}/setup/">Setup</a></li>
+        <li><a href="{{ page.root }}/setup/{{ site.index }}">Setup</a></li>
         <li class="dropdown">
           <a href="{{ page.root }}/" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Episodes <span class="caret"></span></a>
           <ul class="dropdown-menu">
             {% for episode in site.episodes %}
-            <li><a href="{{ page.root }}{{ episode.url }}">{{ episode.title }}</a></li>
+            <li><a href="{{ page.root }}{{ episode.url }}{{ site.index }}">{{ episode.title }}</a></li>
             {% endfor %}
 	    <li role="separator" class="divider"></li>
-            <li><a href="{{ page.root }}/aio/">All in one page (Beta)</a></li>
+            <li><a href="{{ page.root }}/aio/{{ site.index }}">All in one page (Beta)</a></li>
           </ul>
         </li>
 	{% endif %}
@@ -54,18 +54,18 @@
 	{% comment %} Show extras for lessons or if this is the main workshop-template repo (where they contain documentation). {% endcomment %}
 	{% if site.kind == "lesson" or site.github.repository_name == "workshop-template" %}
         <li class="dropdown">
-          <a href="{{ page.root }}/" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Extras <span class="caret"></span></a>
+          <a href="{{ page.root }}/{{ site.index }}" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Extras <span class="caret"></span></a>
           <ul class="dropdown-menu">
-            <li><a href="{{ page.root }}/reference/">Reference</a></li>
+            <li><a href="{{ page.root }}/reference/{{ site.index }}">Reference</a></li>
             {% for extra in site.extras %}
-            <li><a href="{{ page.root }}{{ extra.url }}">{{ extra.title }}</a></li>
+            <li><a href="{{ page.root }}{{ extra.url }}{{ site.index }}">{{ extra.title }}</a></li>
             {% endfor %}
           </ul>
         </li>
 	{% endif %}
 
 	{% comment %} Always show license. {% endcomment %}
-        <li><a href="{{ page.root }}/license/">License</a></li>
+        <li><a href="{{ page.root }}/license/{{ site.index }}">License</a></li>
 	{% if page.source %}
 	{% if page.source == "Rmd" %}
 	<li><a href="{{site.github.repository_url}}/edit/gh-pages/{{page.path|replace: "_episodes", "_episodes_rmd" | replace: ".md", ".Rmd"}}">Improve this page <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span></a></li>

--- a/_includes/syllabus.html
+++ b/_includes/syllabus.html
@@ -17,7 +17,7 @@
   <tr>
     {% if multiday %}<td class="col-md-1"></td>{% endif %}
     <td class="{% if multiday %}col-md-1{% else %}col-md-2{% endif %}"></td>
-    <td class="col-md-3"><a href="{{ page.root }}/setup">Setup</a></td>
+    <td class="col-md-3"><a href="{{ page.root }}/setup/{{ site.index }}">Setup</a></td>
     <td class="col-md-7">Download files required for the lesson</td>
   </tr>
   {% for episode in site.episodes %}
@@ -42,7 +42,7 @@
       <td class="{% if multiday %}col-md-1{% else %}col-md-2{% endif %}">{% if hours < 10 %}0{% endif %}{{ hours }}:{% if minutes < 10 %}0{% endif %}{{ minutes }}</td>
       <td class="col-md-3">
         {% assign lesson_number = lesson_number | plus: 1 %}
-	{{ lesson_number }}. <a href="{{ page.root }}{{ episode.url }}">{{ episode.title }}</a>
+	{{ lesson_number }}. <a href="{{ page.root }}{{ episode.url }}/{{ site.index }}">{{ episode.title }}</a>
       </td>
       <td class="col-md-7">
         {% if episode.break %}

--- a/bin/lesson_initialize.py
+++ b/bin/lesson_initialize.py
@@ -185,6 +185,11 @@ title: "Lesson Title"
 # or if it's a URL, "https://gitter.im/username/ProjectName".
 contact: "mailto:lessons@software-carpentry.org"
 
+# Filename matching webserver config's default index.
+# Set to "index.html" for rendering an offline browsable lesson
+#  but can be left blank when rendering for a webserver
+index: ""
+
 #------------------------------------------------------------
 # Generic settings (should not need to change).
 #------------------------------------------------------------


### PR DESCRIPTION
Note
---
This patch is also the *alternative approach* mentioned in Raniere's [PR 127](https://github.com/swcarpentry/lesson-example/pull/127).

Description
---
Links in the lesson are of the form `http://swcarpentry.github.io/LESSON-NAME/XX-EPISODE-NAME/`. The links works when the lesson is being server by a web server because the server know that it should return the file `_site/XX-EPISODE-NAME/index.html` but will not work if viewing the lesson over file URI scheme because `file:///PATH/TO/LESSON/ROOT/_site/XX-EPISODE-NAME/` is not the same as `file:///PATH/TO/LESSON/ROOT/_site/XX-EPISODE-NAME/index.html`.

Proposal
---
Allow for rendering of internal episode content as 

`scheme:/path/to/LESSON-NAME/XX-EPISODE-NAME/index.html` 
   instead of 
`scheme:/path/to/LESSON-NAME/XX-EPISODE-NAME/`

and of internal auxilliary content as, for example,

`scheme:/path/to/LESSON-NAME/discuss/index.html` 
  instead of 
`scheme:/path/to/LESSON-NAME/XX-EPISODE-NAME/discuss`

Benefits
---
As mentioned before, ability to correctly navigate the lesson without running a web server.

Drawback
---
None: if the proposed variable is left blank.

If the proposed variable is set to `index.html`, link targets are 10  characters longer.

Implementation
---
Applies a `{{ site.index }}` variable which, by default, is **blank**, in which
case all links render as though the variable had not been introduced, 
but which, when set to `index.html`, produces the same link URIs that 
a typical web server would create on the fly.

Alternative Implementation
--- 
Use the variable name `{{ site.permalink }}` as that may mean more to people
who think of the filename in a URI as "permalinks", as in, from a *web page* 
standpoint, as opposed the default index, as in, from a *web server* standpoint,
and which matches the existing nomenclature with the styles template.

Related work
---
This patch is effectively just [vuw-ecs-kevin:offline-capable-lesson@66442fc](https://github.com/vuw-ecs-kevin/offline-capable-lesson/commit/66442fcdf40f967302bc714c4b693f9355eb4061) applied into the swcarpentry:styles repository, the only difference being that the change to  `_config.yml`  is made to  `bin/lesson_initialize.py`  which creates  `_config.yml`.

See https://github.com/vuw-ecs-kevin/offline-capable-lesson/ for the background.


