### PR TITLE
Load methods package

### DIFF
--- a/bin/generate_md_episodes.R
+++ b/bin/generate_md_episodes.R
@@ -1,5 +1,7 @@
 generate_md_episodes <- function() {
 
+    library("methods")
+    
     if (require("knitr") && packageVersion("knitr") < '1.9.19')
         stop("knitr must be version 1.9.20 or higher")
 


### PR DESCRIPTION
Building `md` from `Rmd` in a script like this will break if the `methods` package is not called and the code includes class object routines. See https://github.com/r-spatial/sf/issues/478