### PR TITLE
Fix episode nav wrapping

### DIFF
--- a/_includes/episode_navbar.html
+++ b/_includes/episode_navbar.html
@@ -3,7 +3,7 @@
 {% endcomment %}
 <div class="row">
   <div class="col-xs-1">
-    <h3>
+    <h3 class="text-left">
       {% if page.previous.url %}
       <a href="{{ page.root }}{{ page.previous.url }}"><span class="glyphicon glyphicon-menu-left" aria-hidden="true"></span><span class="sr-only">previous episode</span></a>
       {% else %}
@@ -17,7 +17,7 @@
     {% endif %}
   </div>
   <div class="col-xs-1">
-    <h3>
+    <h3 class="text-right">
       {% if page.next.url %}
       <a href="{{ page.root }}{{ page.next.url }}"><span class="glyphicon glyphicon-menu-right" aria-hidden="true"></span><span class="sr-only">next episode</span></a>
       {% else %}

--- a/_includes/episode_navbar.html
+++ b/_includes/episode_navbar.html
@@ -2,7 +2,7 @@
   Navigation bar for an episode.
 {% endcomment %}
 <div class="row">
-  <div class="col-md-1">
+  <div class="col-xs-1">
     <h3>
       {% if page.previous.url %}
       <a href="{{ page.root }}{{ page.previous.url }}"><span class="glyphicon glyphicon-menu-left" aria-hidden="true"></span><span class="sr-only">previous episode</span></a>
@@ -11,12 +11,12 @@
       {% endif %}
     </h3>
   </div>
-  <div class="col-md-10">
+  <div class="col-xs-10">
     {% if include.episode_navbar_title %}
     <h3 class="maintitle"><a href="{{ page.root }}/">{{ site.title }}</a></h3>
     {% endif %}
   </div>
-  <div class="col-md-1">
+  <div class="col-xs-1">
     <h3>
       {% if page.next.url %}
       <a href="{{ page.root }}{{ page.next.url }}"><span class="glyphicon glyphicon-menu-right" aria-hidden="true"></span><span class="sr-only">next episode</span></a>


### PR DESCRIPTION
By doing this, when a page is heavily zoomed in (e.g. 500%) the navbar icons stay in the same row, rather than breaking onto two different rows. Also pulls the arrows to the outside of the row.

See also: https://github.com/carpentries/instructor-training/pull/521