### PR TITLE
Add current year to copyright of workshop footer

### DIFF
--- a/_includes/workshop_footer.html
+++ b/_includes/workshop_footer.html
@@ -5,7 +5,7 @@
   <div class="row">
     <div class="col-md-6" align="left">
       <h4>
-	Copyright &copy; 2016
+	Copyright &copy; 2016–{{ 'now' | date: "%Y" }}
 	{% if site.carpentry == "swc" %}
 	<a href="{{ site.swc_site }}">Software Carpentry Foundation</a>
 	{% elsif site.carpentry == "dc" %}


### PR DESCRIPTION
Copy of https://github.com/swcarpentry/workshop-template/pull/458/.

For reference, the steps that I used:

~~~
$ git remote add workshop git@github.com:jcoliver/workshop-template.git
$ git fetch workshop
$ git cherry-pick workshop/update-footer-copyright
$ git push origin gh-pages
~~~

Thanks very much to @jcoliver for the original pull request.