### PR TITLE
fix github meta data

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -8,7 +8,7 @@
     <meta http-equiv="last-modified" content="{{ site.time }}">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <!-- meta "search-domain" used for google site search function google_search() -->
-    <meta name="search-domain" value="{{ site.github.url }}">
+    <meta name="search-domain" value="{{ site.github.html_url }}">
     <link rel="stylesheet" type="text/css" href="{{ page.root }}/assets/css/bootstrap.css" />
     <link rel="stylesheet" type="text/css" href="{{ page.root }}/assets/css/bootstrap-theme.css" />
     <link rel="stylesheet" type="text/css" href="{{ page.root }}/assets/css/lesson.css" />


### PR DESCRIPTION
there is a typo in the github metadata documentation. `site.github.url` doesn't exist and cause page building failures in some cases (I haven't been able to figure out which ones). But as indicated in the example (https://help.github.com/articles/repository-metadata-on-github-pages/#usage) the correct variable name is `site.github.html_url`.