### PR TITLE
links.md: remove duplicate line

### DIFF
--- a/_includes/links.md
+++ b/_includes/links.md
@@ -4,7 +4,6 @@
 [coc-reporting]: https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html#reporting-guidelines
 [coc]: https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html
 [concept-maps]: https://carpentries.github.io/instructor-training/05-memory/
-[concept-maps]: https://carpentries.github.io/instructor-training/05-memory/
 [contrib-covenant]: https://contributor-covenant.org/
 [contributing]: {{ site.github.repository_url }}/blob/gh-pages/CONTRIBUTING.md
 [cran-checkpoint]: https://cran.r-project.org/package=checkpoint


### PR DESCRIPTION
Title is pretty self explanatory: there is a duplicate line in `links.md` that causes `make lesson-check` to produce errors:
```bash
# ( in python-novice-inflammation )
$ make lesson-check
_includes/links.md: Duplicate definition of URL https://carpentries.github.io/instructor-training/05-memory/ at line 7
_includes/links.md: Duplicate reference concept-maps at line 7
```