### PR TITLE
bin/util.py: fix error handling for Python 2

### DIFF
--- a/bin/util.py
+++ b/bin/util.py
@@ -160,7 +160,7 @@ def load_yaml(filename):
     try:
         with open(filename, 'r') as reader:
             return yaml.load(reader)
-    except (yaml.YAMLError, FileNotFoundError) as e:
+    except (yaml.YAMLError, IOError) as e:
         print('Unable to load YAML file {0}:\n{1}'.format(filename, e), file=sys.stderr)
         sys.exit(1)
 


### PR DESCRIPTION
`bin/util.py` uses Python 2 that raises `IOError` when file is not found. `FileNotFoundError` is for Python 3