### PR TITLE
Makefile: add docker-serve target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@
 # Settings
 MAKEFILES=Makefile $(wildcard *.mk)
 JEKYLL=jekyll
+JEKYLL_VERSION=3.7.3
 PARSER=bin/markdown_ast.rb
 DST=_site
 
@@ -15,6 +16,10 @@ all : commands
 ## commands         : show all commands.
 commands :
 	@grep -h -E '^##' ${MAKEFILES} | sed -e 's/## //g'
+
+## docker-serve     : use docker to build the site
+docker-serve :
+	docker run --rm -it -v ${PWD}:/srv/jekyll -p 127.0.0.1:4000:4000 jekyll/jekyll:${JEKYLL_VERSION} make serve
 
 ## serve            : run a local server.
 serve : lesson-md


### PR DESCRIPTION
If Docker is installed, `make docker-serve` will download and start a Jekyll container to build and serve the site with hot reloading. This binds the Jekyll webserver to localhost:4000 for security.

JEKYLL_VERSION should be synced with https://pages.github.com/versions/