### PR TITLE
Add README to bin/lesson_initialize.py (#204)

### DIFF
--- a/bin/lesson_initialize.py
+++ b/bin/lesson_initialize.py
@@ -165,6 +165,34 @@ You can also [reach us by email][email].
 [swc-site]: https://software-carpentry.org/
 '''
 
+ROOT_README = '''\
+# FIXME Lesson title
+[![Create a Slack Account with us](https://img.shields.io/badge/Create_Slack_Account-The_Carpentries-071159.svg)](https://swc-slack-invite.herokuapp.com/)
+
+FIXME
+
+## Contributing
+We welcome all contributions to improve the lesson! Maintainers will do their best to help you if you have any 
+questions, concerns, or experience any difficulties along the way.
+
+We'd like to ask you to familiarize yourself with our [Contribution Guide](CONTRIBUTING.md) and have a look at 
+the [more detailed guidelines][lesson-example] on proper formatting, ways to render the lesson locally, and even 
+how to write new episodes.
+
+## Maintainer(s)
+
+* FIXME
+ 
+## Authors
+A list of contributors to the lesson can be found in [AUTHORS](AUTHORS)
+
+## Citation
+To cite this lesson, please consult with [CITATION](CITATION)
+
+[lesson-example]: https://swcarpentry.github.io/lesson-example
+
+'''
+
 ROOT_CONFIG_YML = '''\
 #------------------------------------------------------------
 # Values for this lesson.
@@ -399,6 +427,7 @@ BOILERPLATE = (
     ('AUTHORS', ROOT_AUTHORS),
     ('CITATION', ROOT_CITATION),
     ('CONTRIBUTING.md', ROOT_CONTRIBUTING_MD),
+    ('README.md', ROOT_README),
     ('_config.yml', ROOT_CONFIG_YML),
     ('index.md', ROOT_INDEX_MD),
     ('reference.md', ROOT_REFERENCE_MD),


### PR DESCRIPTION
# Ticket 
Address https://github.com/swcarpentry/styles/issues/204

# Purpose
Add a README template to the lesson initialize script.

Sample boilerplate text based on:
 https://github.com/swcarpentry/python-novice-inflammation

There doesn't appear to be one standard README; I'd be happy to make any improvements as requested.