### PR TITLE
Fix links in LICENSE

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -78,6 +78,6 @@ are registered trademarks of [Community Initiatives][CI].
 
 [cc-by-human]: https://creativecommons.org/licenses/by/4.0/
 [cc-by-legal]: https://creativecommons.org/licenses/by/4.0/legalcode
-[mit-license]: http://opensource.org/licenses/mit-license.html
+[mit-license]: https://opensource.org/licenses/mit-license.html
 [ci]: http://communityin.org/
-[osi]: http://opensource.org
+[osi]: https://opensource.org


### PR DESCRIPTION
The links are NOT broken, they just hit a 301 redirect. Not a big deal by any measure, but it trips link checkers, so might as well fix :stuck_out_tongue_winking_eye: