### PR TITLE
lesson_check.py: Exit with a status of 1 if something was wrong

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ lesson-check :
 
 ## lesson-check-all : validate lesson Markdown, checking line lengths and trailing whitespace.
 lesson-check-all :
-	@bin/lesson_check.py -s . -p ${PARSER} -l -w
+	@bin/lesson_check.py -s . -p ${PARSER} -l -w --permissive
 
 ## unittest         : run unit tests on checking tools.
 unittest :

--- a/bin/lesson_check.py
+++ b/bin/lesson_check.py
@@ -118,8 +118,8 @@ def main():
         checker.check()
 
     args.reporter.report()
-    if args.reporter.messages:
-        raise SystemExit(1)
+    if args.reporter.messages and not args.permissive:
+        exit(1)
 
 
 def parse_args():
@@ -148,6 +148,11 @@ def parse_args():
                       action="store_true",
                       dest='trailing_whitespace',
                       help='Check for trailing whitespace')
+    parser.add_option('--permissive',
+                      default=False,
+                      action="store_true",
+                      dest='permissive',
+                      help='Do not raise an error even if issues are detected')
 
     args, extras = parser.parse_args()
     require(args.parser is not None,

--- a/bin/lesson_check.py
+++ b/bin/lesson_check.py
@@ -118,6 +118,8 @@ def main():
         checker.check()
 
     args.reporter.report()
+    if args.reporter.messages:
+        raise SystemExit(1)
 
 
 def parse_args():


### PR DESCRIPTION
To make `lesson-check` useful in PRs, it has to return non-zero status.

For now, I'm making `lesson-check-all` _permissive_, but this might change in the future.