### PR TITLE
lesson_check: get_val is a static method

### DIFF
--- a/bin/lesson_check.py
+++ b/bin/lesson_check.py
@@ -399,7 +399,8 @@ class CheckBase(object):
                     return False
         return True
 
-    def get_val(self, node, *chain):
+    @staticmethod
+    def get_val(node, *chain):
         """Get value one or more levels down."""
 
         curr = node


### PR DESCRIPTION
`get_val` should be a static method as it does not use `self` or `cls`