### PR TITLE
lesson_check: fix create_checker function

### DIFF
--- a/bin/lesson_check.py
+++ b/bin/lesson_check.py
@@ -271,7 +271,7 @@ def create_checker(args, filename, info):
     for (pat, cls) in CHECKERS:
         if pat.search(filename):
             return cls(args, filename, **info)
-
+    return NotImplemented
 
 class CheckBase(object):
     """Base class for checking Markdown files."""


### PR DESCRIPTION
Function should always return something.
Here, I'm making `create_checker` function return `NotImplemented` if no checker is created/found.