### PR TITLE
Remove unnecessary super call

### DIFF
--- a/bin/util.py
+++ b/bin/util.py
@@ -35,8 +35,6 @@ class Reporter(object):
 
     def __init__(self):
         """Constructor."""
-
-        super(Reporter, self).__init__()
         self.messages = []
 
     def check_field(self, filename, name, values, key, expected=REPORTER_NOT_SET):


### PR DESCRIPTION
Remove unnecessary call to `super` in `Reporter`'s `__init__`.