### PR TITLE
Use Python3-style class declaration

### DIFF
--- a/bin/lesson_check.py
+++ b/bin/lesson_check.py
@@ -273,7 +273,7 @@ def create_checker(args, filename, info):
             return cls(args, filename, **info)
     return NotImplemented
 
-class CheckBase(object):
+class CheckBase:
     """Base class for checking Markdown files."""
 
     def __init__(self, args, filename, metadata, metadata_len, text, lines, doc):

--- a/bin/util.py
+++ b/bin/util.py
@@ -30,7 +30,7 @@ UNWANTED_FILES = [
 REPORTER_NOT_SET = []
 
 
-class Reporter(object):
+class Reporter:
     """Collect and report errors."""
 
     def __init__(self):


### PR DESCRIPTION
With Python3 we no longer need to inherit from `object` because it is added behind the scenes.