### PR TITLE
Make Jekyll ignore .Rproj

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .sass-cache
 __pycache__
 _site
+.Rproj.user

--- a/bin/boilerplate/_config.yml
+++ b/bin/boilerplate/_config.yml
@@ -71,7 +71,8 @@ defaults:
 # Files and directories that are not to be copied.
 exclude:
   - Makefile
-  - bin
+  - bin/
+  - .Rproj.user/
 
 # Turn on built-in syntax highlighting.
 highlighter: rouge


### PR DESCRIPTION
Cover swcarpentry/styles#274

Thanks to @katrinleinweber and @fmichonneau.