### PR TITLE
Simplify sitemaps of The Carpentries lesson sites

### DIFF
--- a/bin/boilerplate/_config.yml
+++ b/bin/boilerplate/_config.yml
@@ -63,10 +63,10 @@ start_time: 0
 collections:
   episodes:
     output: true
-    permalink: /:path/index.html
+    permalink: /episodes/:path.html
   extras:
     output: true
-    permalink: /:path/index.html
+    permalink: /extras/:path.html
 
 # Set the default layout for things in the episodes collection.
 defaults:


### PR DESCRIPTION
I suggest to discuss an option to simplify sitemaps of The Carpentries
lesson sites. Currently, each episode produces a folder with
`index.html` in it:


```
_episode/01-numpy.md   ~> 01-numpy/index.html
_episode/02-loop.md    ~> 02-loop/index.html
```

This PR changes this to:

```
_episode/01-numpy.md   ~> episodes/01-numpy.html
_episode/02-loop.md    ~> episodes/02-loop.html
```