### PR TITLE
Simpler and more robust Makefile

### DIFF
--- a/bin/boilerplate/_config.yml
+++ b/bin/boilerplate/_config.yml
@@ -89,6 +89,7 @@ defaults:
 # Files and directories that are not to be copied.
 exclude:
   - Makefile
+  - *.mk
   - bin/
   - .Rproj.user/
   - .vendor/

--- a/commands.mk
+++ b/commands.mk
@@ -1,0 +1,69 @@
+#  JEKYLL_BUILD_CMD
+#  JEKYLL_CLEAN_CMD
+#  JEKYLL_SERVE_CMD
+ifneq (, $(JEKYLL))
+  JEKYLL_CMD := jekyll
+  # We can use 'bundle exec' only if we have a Gemfile
+  ifneq (, $(wildcard ./Gemfile))
+    ifneq (, $(BUNDLE))
+      JEKYLL_CMD := bundle exec $(JEKYLL_CMD)
+    endif
+  endif
+  JEKYLL_BUILD_CMD := $(JEKYLL_CMD) build
+  JEKYLL_CLEAN_CMD := $(JEKYLL_CMD) clean
+  JEKYLL_SERVE_CMD := $(JEKYLL_CMD) serve -H $(HOST) -P $(PORT)
+else
+  JEKYLL_BUILD_CMD = $(error Can't build a website: Jekyll not found)
+  JEKYLL_CLEAN_CMD = rm -rf $(DST) .jekyll-metadata .sass-cache
+  JEKYLL_SERVE_CMD = $(error Can't serve a website: Jekyll not found)
+endif
+
+
+#  DOCKER_SERVE_CMD
+ifneq (, $(DOCKER))
+  DOCKER_SERVE_CMD = \
+  $(DOCKER) run --rm -it \
+  --volume ${PWD}:/srv/jekyll \
+  --volume ${PWD}/.docker-vendor/bundle:/usr/local/bundle \
+  --publish $(HOST):$(PORT):4000 \
+  jekyll/jekyll:${JEKYLL_VERSION} \
+  bin/run-make-docker-serve.sh
+else
+  DOCKER_SERVE_CMD = $(error Can't serve the site using Docker: Docker not found)
+endif
+
+
+#  REPO_CHECK_CMD
+#  WORKSHOP_CHECK_CMD
+#  LESSON_CHECK_CMD
+#  LESSON_CHECK_ALL_CMD
+#  UNITTEST_CMD
+ifneq (, $(PYTHON))
+  REPO_CHECK_CMD = ${PYTHON} bin/repo_check.py -s .
+  WORKSHOP_CHECK_CMD = ${PYTHON} bin/workshop_check.py .
+  LESSON_CHECK_CMD = ${PYTHON} bin/lesson_check.py -s . -p ${PARSER} -r _includes/links.md
+  LESSON_CHECL_ALL_CMD = ${PYTHON} bin/lesson_check.py -s . -p ${PARSER} -r _includes/links.md -l -w --permissive
+  UNITTEST_CMD = ${PYTHON} bin/test_lesson_check.py
+else
+  REPO_CHECK_CMD = $(error Can't check repository settings: Python 3 not found!)
+  WORKSHOP_CHECK_CMD = $(error Can't check workshop homepage: Python 3 not found)
+  LESSON_CHECK_CMD = $(error Can't validate lesson files: Python 3 not found)
+  LESSON_CHECK_ALL_CMD = $(error Can't validate lesson files: Python 3 not found)
+  UNITTEST_CMD = $(error Can't perform unit testing: Python 3 not found)
+endif
+
+
+#  BUNDLE_INSTALL_CMD
+#  BUNDLE_LOCK_CMD
+ifneq (, $(BUNDLE))
+  define BUNDLE_INSTALL_CMD
+  $(BUNDLE) install --path .vendor/bundle
+  $(BUNDLE) update
+  endef
+  BUNDLE_LOCK_CMD = $(BUNDLE) lock --update
+else
+  BUNDLE_INSTALL_CMD = $(error Can't create .vendor/bundle: Bundle not found)
+  BUNDLE_LOCK_CMD = $(error Can't create/update Gemfile.lock: Bundle not found)
+endif
+
+

--- a/tools.mk
+++ b/tools.mk
@@ -1,0 +1,69 @@
+# Detect required programs: Gem, Docker, Rscript, Jekyll
+GEM ?= $(shell which gem 2>/dev/null)
+DOCKER ?= $(shell which docker 2>/dev/null)
+RSCRIPT ?= $(shell which Rscript 2>/dev/null)
+JEKYLL ?= $(shell which jekyll 2>/dev/null)
+BUNDLE ?= $(shell which bundle 2>/dev/null)
+
+
+# Determine Jekyll version that we need
+ifneq (, $(JEKYLL_VERSION))
+  # Get Jekyll version from the Gemfile.lock
+  ifneq (, $(wildcard ./Gemfile.lock))
+    JEKYLL_VERSION := $(shell sed -n "/jekyll\ (=.*)/s|.*(= \(.*\))|\1|p" Gemfile.lock)
+  endif
+
+  ifeq (, $(JEKYLL_VERSION))
+    # Sync with https://pages.github.com/versions
+    JEKYLL_VERSION := 3.8.5
+  endif
+endif
+
+
+# Python
+# Check Python 3 is installed and determine if it's called via python3 or python
+PYTHON3_EXE := $(shell which python3 2>/dev/null)
+ifneq (, $(PYTHON3_EXE))
+  ifeq (,$(findstring Microsoft/WindowsApps/python3,$(subst \,/,$(PYTHON3_EXE))))
+    PYTHON := python3
+  endif
+endif
+
+ifeq (,$(PYTHON))
+  PYTHON_EXE := $(shell which python 2>/dev/null)
+  ifneq (, $(PYTHON_EXE))
+    PYTHON_VERSION_FULL := $(wordlist 2,4,$(subst ., ,$(shell python --version 2>&1)))
+    PYTHON_VERSION_MAJOR := $(word 1,${PYTHON_VERSION_FULL})
+    ifneq (3, ${PYTHON_VERSION_MAJOR})
+      $(warning Your system does not appear to have Python 3 installed)
+    else
+      PYTHON := python
+    endif
+  else
+      $(warning Your system does not appear to have any Python installed)
+  endif
+endif
+
+# RMarkdown files
+RMD_SRC = $(wildcard _episodes_rmd/??-*.Rmd)
+RMD_DST = $(patsubst _episodes_rmd/%.Rmd,_episodes/%.md,$(RMD_SRC))
+
+# Lesson source files in the order they appear in the navigation menu.
+MARKDOWN_SRC = \
+  index.md \
+  CODE_OF_CONDUCT.md \
+  setup.md \
+  $(sort $(wildcard _episodes/*.md)) \
+  reference.md \
+  $(sort $(wildcard _extras/*.md)) \
+  LICENSE.md
+
+# Generated lesson files in the order they appear in the navigation menu.
+HTML_DST = \
+  ${DST}/index.html \
+  ${DST}/conduct/index.html \
+  ${DST}/setup/index.html \
+  $(patsubst _episodes/%.md,${DST}/%/index.html,$(sort $(wildcard _episodes/*.md))) \
+  ${DST}/reference/index.html \
+  $(patsubst _extras/%.md,${DST}/%/index.html,$(sort $(wildcard _extras/*.md))) \
+  ${DST}/license/index.html


### PR DESCRIPTION
Reworked the Makefile to make it simpler (to understand) and more robust so that people with no experience with Make would see clear error messages when something is not working.

Clear error messages require things like: 
```Makefile
target:
ifneq (, $(TOOL))
    @$(TOOL) subcommand
else
    $(error sorry can't do)
endif
```

To avoid repetition, I extracted these `ifneq .... endif` to `commands.mk` and created `TOOL_CMD` for each `TOOL`.