### PR TITLE
License is not a copyright. License info ID

### DIFF
--- a/_includes/lesson_footer.html
+++ b/_includes/lesson_footer.html
@@ -6,7 +6,7 @@
 
 <footer>
   <div class="row">
-    <div class="col-md-6 copyright" align="left">
+    <div class="col-md-6 license" id="license-info" align="left">
 	{% if site.carpentry == "swc" %}
 	Licensed under <a href="{{ site.cc_by_human }}">CC-BY 4.0</a> 2018–{{ 'now' | date: "%Y" }}
 	by <a href="{{ site.carpentries_site }}">The Carpentries</a>

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -16,6 +16,7 @@
     <link rel="stylesheet" type="text/css" href="{{ relative_root_path }}/assets/css/bootstrap-theme.css" />
     <link rel="stylesheet" type="text/css" href="{{ relative_root_path }}/assets/css/lesson.css" />
     <link rel="stylesheet" type="text/css" href="{{ relative_root_path }}/assets/css/syntax.css" />
+    <link rel="license" href="#license-info" />
 
     {% include favicons.html %}
 

--- a/assets/css/lesson.scss
+++ b/assets/css/lesson.scss
@@ -227,7 +227,7 @@ article pre {
   text-align: center;
 }
 
-footer .copyright,
+footer .license,
 footer .help-links
 {
     font-size: inherit;


### PR DESCRIPTION
Copyright and license are different things. So I propose to rename the class of the `div` element containing the license information from `copyright` to `license` and add an `id` attribute so that we can refer to it in the header using:

```
<link rel="license" href="#license-info" />
```

This is the way to declare which license applies to the page. Alternatively, we can also point directly to `href="{{ site.cc_by_human }}` as we do in the footer. 