### PR TITLE
add warning blockquote style, carpentries/styles#49

### DIFF
--- a/assets/css/lesson.scss
+++ b/assets/css/lesson.scss
@@ -16,6 +16,7 @@ $color-source:      #360084 !default;
 
 // blockquotes
 $color-callout:     #f4fd9c !default;
+$color-caution:     #cf000e !default;
 $color-challenge:   #eec275 !default;
 $color-checklist:   #dfd2a0 !default;
 $color-discussion:  #eec275 !default;
@@ -136,6 +137,7 @@ $codeblock-padding: 5px !default;
 }
 
 .callout{ @include bkSetup($color-callout, "\e146"); }
+.caution{ @include bkSetup($color-caution, "\e107"); }
 .challenge{ @include bkSetup($color-challenge, "\270f"); }
 .checklist{ @include bkSetup($color-checklist, "\e067"); }
 .discussion{ @include bkSetup($color-discussion, "\e123"); }


### PR DESCRIPTION
This PR adds a blockquote style for warnings or errors, see #49.

See https://carpentries.github.io/lesson-example/04-formatting/index.html#special-blockquotes for a comparison against other blockquote styles. See https://getbootstrap.com/docs/3.3/components/ for a gallery of alternative icons.

![Screenshot from 2020-07-19 14-33-25](https://user-images.githubusercontent.com/7844578/87882583-e7f10600-c9ce-11ea-94ea-73c867ba014c.png)

If this looks good to people, I've prepared a PR to the `lesson-example` repository at: https://github.com/jsta/lesson-example/tree/warningcallout
