### PR TITLE
Make links in code tags distinguishable

### DIFF
--- a/assets/css/lesson.scss
+++ b/assets/css/lesson.scss
@@ -181,10 +181,14 @@ blockquote :not(h2) + p {
 
 blockquote { font-size: inherit; }
 
+a code {
+  color: #006cad;
+}
+
 code {
   white-space: nowrap;
   padding: 2px 5px;
-  color: #006cad;
+  color: #24292e;
   background-color: #e7e7e7;
 }
 


### PR DESCRIPTION
Before:

![screenshot_2020-07-23_20-09-47_827772726](https://user-images.githubusercontent.com/122319/88322126-8909f480-cd20-11ea-9b01-7ee14a6c9dac.png)

After:

![screenshot_2020-07-23_20-09-13_796466359](https://user-images.githubusercontent.com/122319/88322147-932bf300-cd20-11ea-8e5a-3944a31f6679.png)

Following the same style as GitHub - `A code block` vs [`A linked code block`]()

Fixes carpentries/styles#254 