### PR TITLE
Makefile: fix comment in front of `lesson-check`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ lesson-md : ${RMD_DST}
 _episodes/%.md: _episodes_rmd/%.Rmd
 	@bin/knit_lessons.sh $< $@
 
-# * lesson-check     : validate lesson Markdown
+## * lesson-check     : validate lesson Markdown
 lesson-check : lesson-fixme
 	@${PYTHON} bin/lesson_check.py -s . -p ${PARSER} -r _includes/links.md
 


### PR DESCRIPTION
Comments prepended with `##` appear in the output of `make commands`.
This commit changes `#` to `##` in front of `lesson-check` so that it
appears in the output of `make commands`.