### PR TITLE
repo_check.py: allow URLs not ending with .git

### DIFF
--- a/bin/repo_check.py
+++ b/bin/repo_check.py
@@ -20,7 +20,7 @@ except ImportError:
 
 
 # Pattern to match Git command-line output for remotes => (user name, project name).
-P_GIT_REMOTE = re.compile(r'upstream\s+[^:]+:([^/]+)/([^.]+)\.git\s+\(fetch\)')
+P_GIT_REMOTE = re.compile(r'upstream\s+[^:]+:([^/]+)/([^.]+)(\.git)?\s+\(fetch\)')
 
 # Repository URL format string.
 F_REPO_URL = 'https://github.com/{0}/{1}/'


### PR DESCRIPTION
New pattern allows `repo_check.py` script to handle cases when URL
is something like `https://github.com/carpentries/lesson-name`.