### PR TITLE
repo_check.py: match https repositories

### DIFF
--- a/bin/repo_check.py
+++ b/bin/repo_check.py
@@ -20,7 +20,7 @@ except ImportError:
 
 
 # Pattern to match Git command-line output for remotes => (user name, project name).
-P_GIT_REMOTE = re.compile(r'upstream\s+[^:]+:([^/]+)/([^.]+)(\.git)?\s+\(fetch\)')
+P_GIT_REMOTE = re.compile(r'upstream\s+(?:https://|git@)github.com[:/]([^/]+)/([^.]+)(\.git)?\s+\(fetch\)')
 
 # Repository URL format string.
 F_REPO_URL = 'https://github.com/{0}/{1}/'


### PR DESCRIPTION
Current pattern matches `git@github.com:/USER/repo` URLs but doesn't `https://github.com/USER/repo`.
This PR allows https repositories