### PR TITLE
Makefile: don't use /bin/bash shell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,3 @@
-# Use /bin/bash instead of /bin/sh
-ifneq (,$(wildcard /bin/bash))
-  export SHELL = /bin/bash
-else ifneq (,$(wildcard /usr/bin/bash))
-  export SHELL = /usr/bin/bash
-endif
-
 ## ========================================
 ## Commands for both workshop and lesson websites.
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 # Use /bin/bash instead of /bin/sh
-export SHELL = /bin/bash
+ifneq (,$(wildcard /bin/bash))
+  export SHELL = /bin/bash
+else ifneq (,$(wildcard /usr/bin/bash))
+  export SHELL = /usr/bin/bash
+endif
 
 ## ========================================
 ## Commands for both workshop and lesson websites.


### PR DESCRIPTION
On some platforms `bash` executable is in `/bin` folder, whereas on other system itis in `/usr/bin`.
Instead of assuming that it's in the `/bin` directory, we can check whether `/bin/bash` or `/usr/bin/bash` exist.