### PR TITLE
Fix Python scripts for Windows: UTF-8 encoding

### DIFF
--- a/bin/lesson_check.py
+++ b/bin/lesson_check.py
@@ -215,7 +215,7 @@ def read_references(reporter, ref_path):
     result = {}
     urls_seen = set()
 
-    with open(ref_path, 'r') as reader:
+    with open(ref_path, 'r', encoding='utf-8') as reader:
         for (num, line) in enumerate(reader, 1):
 
             if P_INTERNAL_INCLUDE_LINK.search(line): continue

--- a/bin/util.py
+++ b/bin/util.py
@@ -105,7 +105,7 @@ def read_markdown(parser, path):
     """
 
     # Split and extract YAML (if present).
-    with open(path, 'r') as reader:
+    with open(path, 'r', encoding='utf-8') as reader:
         body = reader.read()
     metadata_raw, metadata_yaml, body = split_metadata(path, body)
 
@@ -160,7 +160,7 @@ def load_yaml(filename):
     """
 
     try:
-        with open(filename, 'r') as reader:
+        with open(filename, 'r', encoding='utf-8') as reader:
             return yaml.load(reader, Loader=yaml.SafeLoader)
     except (yaml.YAMLError, IOError) as e:
         print('Unable to load YAML file {0}:\n{1}'.format(

--- a/bin/workshop_check.py
+++ b/bin/workshop_check.py
@@ -408,7 +408,7 @@ def main():
     reporter = Reporter()
     check_config(reporter, config_file)
     check_unwanted_files(root_dir, reporter)
-    with open(index_file) as reader:
+    with open(index_file, encoding='utf-8') as reader:
         data = reader.read()
         check_file(reporter, index_file, data)
     reporter.report()


### PR DESCRIPTION
the default encoding on Windows is cp1252, so
we have to specify that the files we open have a different (UTF-8) encoding.