### PR TITLE
Makefile: fix 'lesson-fixme' target for Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,7 @@ lesson-files :
 
 ## * lesson-fixme     : show FIXME markers embedded in source files
 lesson-fixme :
-	@fgrep -i -n FIXME ${MARKDOWN_SRC} || true
+	@grep --fixed-strings --word-regexp --line-number --no-messages FIXME ${MARKDOWN_SRC} || true
 
 ##
 ## IV. Auxililary (plumbing) commands


### PR DESCRIPTION
Git for Windows doesn't provide fgrep, which is a shortcut
to call `grep -F` on Mac and Linux. Instead, we have to use
normal flags (`-F`, `-...`).

Here, I'm also applying the following changes:
1. convert all options (`-`) to long options (`--`).
2. remove case-insensitive flag.
3. add -w (--word-regexp).
4. add `--no-messages` to make `grep` not complain about missing files.