### PR TITLE
only display Episodes drop-down if we have episodes to show

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -49,6 +49,7 @@
         <li><a href="{{ relative_root_path }}{% link setup.md %}">Setup</a></li>
 
         {% comment %} Show lesson episodes for lessons. {% endcomment %}
+        {% if lesson_episodes.length > 0 %}
         <li class="dropdown">
           <a href="{{ relative_root_path }}/" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Episodes <span class="caret"></span></a>
           <ul class="dropdown-menu">
@@ -64,6 +65,7 @@
             <li><a href="{{ relative_root_path }}{% link aio.md %}">All in one page (Beta)</a></li>
           </ul>
         </li>
+        {% endif %}
 	{% endif %}
 
 	{% comment %} Show extras for lessons or if this is the main workshop-template repo (where they contain documentation). {% endcomment %}


### PR DESCRIPTION
follow up from: https://github.com/carpentries/carpentries-theme/issues/6#issuecomment-671973655

Workshop overview sites don't have episodes so hiding the Episodes in this context makes sense.