### PR TITLE
Makefile: various improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,23 +45,22 @@ endif
 .PHONY: site site-offline serve serve-offline docker-serve repo-check clean clean-rmd
 
 ## * serve            : render website and run a local server
-serve : update-bundle serve-offline
+serve : update-bundle lesson-md index.md
 	$(info ==> $@ [$^])
-	@:
+	@$(BUNDLE) exec jekyll serve
 
 ## * site             : build website but do not run a server
-site : update-bundle site-offline
+site : update-bundle lesson-md index.md
 	$(info ==> $@ [$^])
-	@:
+	@$(BUNDLE) exec jekyll build
 
 ## * serve-offline    : same as 'serve' but don't update Ruby gems
-serve-offline : lesson-md index.md bundler .vendor/bundle
+serve-offline : lesson-md index.md | bundler check-bundle
 	$(info ==> $@ [$^])
 	@$(BUNDLE) exec jekyll serve
 
 ## * site-offline     : same as 'site' but don't update Ruby gems
-site-offline : lesson-md index.md bundler .vendor/bundle
-	$(info ==> $@ [$^])
+site-offline : lesson-md index.md | bundler check-bundle
 	@$(BUNDLE) exec jekyll build
 
 
@@ -195,7 +194,7 @@ lesson-fixme :
 ## IV. Auxililary (plumbing) commands
 ## =================================================
 
-.PHONY : commands python bundler bundle update-bundle
+.PHONY : commands python bundler bundle update-bundle check-bundle
 
 ## * commands         : show all commands
 commands :
@@ -221,8 +220,8 @@ endif
 	$(info ==> $@ [$^])
 	@$(BUNDLE) config set --local path '.vendor/bundle'
 
-## * install-bundle   : install Ruby gems
-install-bundle : .vendor/bundle
+## * bundle   : install Ruby gems
+bundle : .vendor/bundle
 	$(info ==> $@ [$^])
 	@:
 
@@ -230,6 +229,14 @@ install-bundle : .vendor/bundle
 	$(info ==> $@ [$^])
 	@$(BUNDLE) install --quiet
 	@touch .vendor/bundle
+
+check-bundle:
+ifeq (, $(wildcard .vendor/bundle))
+	$(error Required Ruby gems not found. Install them with 'make bundle')
+else
+	@:
+endif
+
 
 ## * update-bundle    : update Ruby gems
 update-bundle : Gemfile.lock .bundle/config | bundler

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ endif
 
 ## * serve            : render website and run a local server
 serve : lesson-md index.md bundler .vendor/bundle
-	@bundle exec jekyll serve
+	@$(BUNDLE) exec jekyll serve
 
 ## * site             : build website but do not run a server
 site : update-bundle site-offline
@@ -55,7 +55,7 @@ site : update-bundle site-offline
 
 ## * site-offline     : same as 'site' but doesn't update Ruby gems
 site-offline : lesson-md index.md bundler .vendor/bundle
-	@bundle exec jekyll build
+	@$(BUNDLE) exec jekyll build
 
 ## * docker-serve     : use Docker to serve the site
 docker-serve :
@@ -195,7 +195,7 @@ else
 endif
 
 .bundle/config : bundler
-	@bundle config set --local path '.vendor/bundle'
+	@$(BUNDLE) config set --local path '.vendor/bundle'
 
 ## * bundle           : install Ruby gems (required for building lesson website locally)
 bundle : .vendor/bundle
@@ -203,13 +203,13 @@ bundle : .vendor/bundle
 
 .vendor/bundle: Gemfile.lock .bundle/config bundler
 	$(info Installing Ruby gems)
-	@bundle install
+	@$(BUNDLE) install
 	@touch .vendor/bundle
 
 ## * update-bundle    : update Ruby gems (required for building lesson website locally)
 update-bundle : Gemfile.lock .bundle/config bundler
 	$(info Updating Ruby gems)
-	@bundle update --quiet
+	@$(BUNDLE) update --quiet
 	@touch .vendor/bundle
 
 Gemfile:
@@ -220,7 +220,7 @@ else
 endif
 
 Gemfile.lock: Gemfile bundler
-	@bundle lock --update
+	@$(BUNDLE) lock --update
 
 index.md :
 ifeq (, $(wildcard index.md))

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ DST=_site
 # Find Docker
 DOCKER := $(shell which docker 2>/dev/null)
 
+# Find Bundler
 BUNDLE := $(shell which bundle 2>/dev/null)
 
 # Check Python 3 is installed and determine if it's called via python3 or python
@@ -188,25 +189,26 @@ endif
 
 bundler :
 ifeq (, $(BUNDLE))
-	$(error Please install Bundler using 'gem install bundler')
+	$(error Please install Bundler using 'gem install --user-install bundler')
 else
 	@:
 endif
+
+.bundle/config : bundler
+	@bundle config set --local path '.vendor/bundle'
 
 ## * bundle           : install Ruby gems (required for building lesson website locally)
 bundle : .vendor/bundle
 	@:
 
-.vendor/bundle: Gemfile.lock bundler
+.vendor/bundle: Gemfile.lock .bundle/config bundler
 	$(info Installing Ruby gems)
-	@bundle config set --local path '.vendor/bundle'
 	@bundle install
 	@touch .vendor/bundle
 
 ## * update-bundle    : update Ruby gems (required for building lesson website locally)
-update-bundle : Gemfile.lock bundler
+update-bundle : Gemfile.lock .bundle/config bundler
 	$(info Updating Ruby gems)
-	@bundle config set --local path '.vendor/bundle'
 	@bundle update --quiet
 	@touch .vendor/bundle
 


### PR DESCRIPTION
0. ~Use proper `bundle config set --local path ...` syntax instead of (incorrect) `bundle config --local set path ...`~ (implemented in #559).
1. ~Decide whether to use `bundle` or `jekyll` based on the presence of `Gemfile` or `Gemfile.lock`~
2. ~Use `$(SHELL)` to call `bin/knit_lessons.sh`: this lets us avoid relying on `/usr/bin/env` finding `bash`.~ (implemented in #562)
3. New `bundle` target for building `.vendor/bundle` directory with required gems:
     a. This is an alias for `.vendor/bundle` target which depends on `Gemfile` and `Gemfile.lock`
     b. It installs/updates bundled gems only if necessary
4. Empty `Gemfile` target for lessons that don't use it.
     a. `Gemfile.lock` target that creates it based on `Gemfile`
5. ~`clean` target: remove `.vendor` and `.bundle` directories and `Gemfile.lock` file.~ (implemented in #560)