### PR TITLE
fix: tighten definitions of highlighter

### DIFF
--- a/assets/css/lesson.scss
+++ b/assets/css/lesson.scss
@@ -38,44 +38,44 @@ $color-testimonial: #fc8dc1 !default;
     border-radius: 4px 0 0 4px;
 }
 
-.error   { @include cdSetup($color-error); }
-.warning { @include cdSetup($color-warning); }
-.output  { @include cdSetup($color-output); }
-.source  { @include cdSetup($color-source); }
+div.error   { @include cdSetup($color-error); }
+div.warning { @include cdSetup($color-warning); }
+div.output  { @include cdSetup($color-output); }
+div.source  { @include cdSetup($color-source); }
 
-.bash, div.language-bash     { @include cdSetup($color-source); }
-.make, div.language-make     { @include cdSetup($color-source); }
-.matlab, div.language-matlab { @include cdSetup($color-source); }
-.python, div.language-python { @include cdSetup($color-source); }
-.r, div.language-r           { @include cdSetup($color-source); }
-.sql, div.language-sql       { @include cdSetup($color-source); }
+div.bash, div.language-bash     { @include cdSetup($color-source); }
+div.make, div.language-make     { @include cdSetup($color-source); }
+div.matlab, div.language-matlab { @include cdSetup($color-source); }
+div.python, div.language-python { @include cdSetup($color-source); }
+div.r, div.language-r           { @include cdSetup($color-source); }
+div.sql, div.language-sql       { @include cdSetup($color-source); }
 
-.error::before,
-.warning:before,
-.output::before,
-.source::before,
-.bash::before, div.language-bash::before,
-.make::before, div.language-make::before,
-.matlab::before, div.language-matlab::before,
-.python::before, div.language-python::before,
-.r::before, div.language-r::before,
-.sql::before, div.language-sql::before {
+div.error::before,
+div.warning:before,
+div.output::before,
+div.source::before,
+div.bash::before, div.language-bash::before,
+div.make::before, div.language-make::before,
+div.matlab::before, div.language-matlab::before,
+div.python::before, div.language-python::before,
+div.r::before, div.language-r::before,
+div.sql::before, div.language-sql::before {
     background-color: #f2eff6;
     display: block;
     font-weight: bold;
     padding: 5px 10px;
 }
 
-.error::before  { background-color: #ffebe6; content: "Error"; }
-.warning:before { background-color: #f8f4e8; content:" Warning"; }
-.output::before { background-color: #efefef; content: "Output"; }
-.source::before { content: "Code"; }
-.bash::before, div.language-bash::before { content: "Bash"; }
-.make::before, div.language-make::before { content: "Make"; }
-.matlab::before, div.language-matlab::before { content: "Matlab"; }
-.python::before, div.language-python::before { content: "Python"; }
-.r::before, div.language-r::before { content: "R"; }
-.sql::before, div.language-sql::before { content: "SQL"; }
+div.error::before  { background-color: #ffebe6; content: "Error"; }
+div.warning:before { background-color: #f8f4e8; content:" Warning"; }
+div.output::before { background-color: #efefef; content: "Output"; }
+div.source::before { content: "Code"; }
+div.bash::before, div.language-bash::before { content: "Bash"; }
+div.make::before, div.language-make::before { content: "Make"; }
+div.matlab::before, div.language-matlab::before { content: "Matlab"; }
+div.python::before, div.language-python::before { content: "Python"; }
+div.r::before, div.language-r::before { content: "R"; }
+div.sql::before, div.language-sql::before { content: "SQL"; }
 
 // Tab panels are used on Setup pages to show instructions for different Operating Systems
 .tab-pane {

--- a/assets/css/lesson.scss
+++ b/assets/css/lesson.scss
@@ -43,23 +43,23 @@ $color-testimonial: #fc8dc1 !default;
 .output  { @include cdSetup($color-output); }
 .source  { @include cdSetup($color-source); }
 
-.bash, .language-bash     { @include cdSetup($color-source); }
-.make, .language-make     { @include cdSetup($color-source); }
-.matlab, .language-matlab { @include cdSetup($color-source); }
-.python, .language-python { @include cdSetup($color-source); }
-.r, .language-r           { @include cdSetup($color-source); }
-.sql, .language-sql       { @include cdSetup($color-source); }
+.bash, div.language-bash     { @include cdSetup($color-source); }
+.make, div.language-make     { @include cdSetup($color-source); }
+.matlab, div.language-matlab { @include cdSetup($color-source); }
+.python, div.language-python { @include cdSetup($color-source); }
+.r, div.language-r           { @include cdSetup($color-source); }
+.sql, div.language-sql       { @include cdSetup($color-source); }
 
 .error::before,
 .warning:before,
 .output::before,
 .source::before,
-.bash::before, .language-bash::before,
-.make::before, .language-make::before,
-.matlab::before, .language-matlab::before,
-.python::before, .language-python::before,
-.r::before, .language-r::before,
-.sql::before, .language-sql::before {
+.bash::before, div.language-bash::before,
+.make::before, div.language-make::before,
+.matlab::before, div.language-matlab::before,
+.python::before, div.language-python::before,
+.r::before, div.language-r::before,
+.sql::before, div.language-sql::before {
     background-color: #f2eff6;
     display: block;
     font-weight: bold;
@@ -70,12 +70,12 @@ $color-testimonial: #fc8dc1 !default;
 .warning:before { background-color: #f8f4e8; content:" Warning"; }
 .output::before { background-color: #efefef; content: "Output"; }
 .source::before { content: "Code"; }
-.bash::before, .language-bash::before { content: "Bash"; }
-.make::before, .language-make::before { content: "Make"; }
-.matlab::before, .language-matlab::before { content: "Matlab"; }
-.python::before, .language-python::before { content: "Python"; }
-.r::before, .language-r::before { content: "R"; }
-.sql::before, .language-sql::before { content: "SQL"; }
+.bash::before, div.language-bash::before { content: "Bash"; }
+.make::before, div.language-make::before { content: "Make"; }
+.matlab::before, div.language-matlab::before { content: "Matlab"; }
+.python::before, div.language-python::before { content: "Python"; }
+.r::before, div.language-r::before { content: "R"; }
+.sql::before, div.language-sql::before { content: "SQL"; }
 
 // Tab panels are used on Setup pages to show instructions for different Operating Systems
 .tab-pane {


### PR DESCRIPTION
The current style sheet is too greedy in trying to apply highlighter styles; when you use a structure like this:

```
{% highlight cmake %}
{% include code/00-intro/CMakeLists.txt %}
{% endhighlight %}
```

Then you end up with different structure, where the highlighter styles get applied to something that is not a div, and you get something like this:


![](https://user-images.githubusercontent.com/4616906/90554975-a3d75980-e164-11ea-9a06-7326b96746d1.png)


This tightens up the definitions a little to make sure they don't get applied to non-divs.