### PR TITLE
GitHub Actions: better workflow and job names

### DIFF
--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -1,11 +1,11 @@
-name: Template
+name: Test template
 on:
   push:
     branches: gh-pages
   pull_request:
 jobs:
   check-template:
-    name: Test lesson template
+    name: ${{ matrix.lesson-name }} (${{ matrix.os-name }})
     if: github.repository == 'carpentries/styles'
     runs-on: ${{ matrix.os }}
     strategy:
@@ -13,6 +13,19 @@ jobs:
       matrix:
         lesson: [swcarpentry/shell-novice, datacarpentry/r-intro-geospatial, librarycarpentry/lc-git]
         os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - os: ubuntu-latest
+            os-name: Ubuntu
+          - os: macos-latest
+            os-name: macOS
+          - os: windows-latest
+            os-name: Windows
+          - lesson: swcarpentry/shell-novice
+            lesson-name: (SWC) Shell novice
+          - lesson: datacarpentry/r-intro-geospatial
+            lesson-name: (DC) R Intro Geospatial
+          - lesson: librarycarpentry/lc-git
+            lesson-name: (LC) Intro to Git
     defaults:
       run:
         shell: bash # forces 'Git for Windows' on Windows


### PR DESCRIPTION
This is an attempt to improve the workflow and job names. Open for suggestions/discussion.
Currently, job names are too long and are cut off:

![image](https://user-images.githubusercontent.com/13123663/91081845-6152c880-e60d-11ea-8e53-5dffca7d0824.png)

so one has to click "Details" to go to the Actions tab to see what was tested where. I suggest to shorten job names a little bit so that we can see all the important info without having to click anywhere:

![image](https://user-images.githubusercontent.com/13123663/91081964-90693a00-e60d-11ea-97a6-c1b81542b374.png)

I'm not sure if putting `()` around the Carpentry names improves things so suggestions are welcome.