### PR TITLE
GitHub Action: website.yml: don't run in forks

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -5,7 +5,7 @@ on:
   pull_request: []
 jobs:
   build-website:
-    if: github.repository != 'carpentries/styles'
+    if: github.repository != 'carpentries/styles' && (github.repository_owner == 'swcarpentry' || github.repository_owner == 'datacarpentry' || github.repository_owner == 'librarycarpentry' || github.repository_owner == 'carpentries')
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
Our "Build website" Action runs in forks. I propose to not run it in people's forks and restrict it to the 4 Carpentries' organizations (not sure we need 'carpentries' though). Unfortunately, proposed syntax is the only syntax that I could come up with to achieve this goal (and I'm not sure there is a better solution).