### PR TITLE
GH Website action: rename + don't use lesson directory

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -1,4 +1,4 @@
-name: Build website
+name: Website
 on:
   push:
     branches: gh-pages
@@ -37,7 +37,6 @@ jobs:
 
       - name: Look for R-markdown files
         id: check-rmd
-        working-directory: lesson
         run: |
           echo "::set-output name=count::$(shopt -s nullglob; files=($(find . -iname '*.Rmd')); echo ${#files[@]})"
 
@@ -55,7 +54,6 @@ jobs:
 
       - name: Query dependencies
         if: steps.check-rmd.outputs.count != 0
-        working-directory: lesson
         run: |
           source('bin/dependencies.R')
           deps <- identify_dependencies()
@@ -74,7 +72,6 @@ jobs:
 
       - name: Install system dependencies for R packages
         if: steps.check-rmd.outputs.count != 0
-        working-directory: lesson
         run: |
           while read -r cmd
           do


### PR DESCRIPTION
When 'Website' action tests a lesson, it checks out repositories into the current working directory: 'lesson' directory doesn't exist.  As a result, steps that use "lesson" as the working directory fail. This PR fixes this.


<details>
<summary><strong>Instructions</strong></summary>

Thanks for contributing! :heart:

If this contribution is for instructor training, please email the link to this contribution to
checkout@carpentries.org so we can record your progress. You've completed your contribution
step for instructor checkout by submitting this contribution!

Keep in mind that **lesson maintainers are volunteers** and it may take them some time to
respond to your contribution. Although not all contributions can be incorporated into the lesson
materials, we appreciate your time and effort to improve the curriculum. If you have any questions
about the lesson maintenance process or would like to volunteer your time as a contribution
reviewer, please contact The Carpentries Team at team@carpentries.org.

You may delete these instructions from your comment.

\- The Carpentries
</details>