### PR TITLE
add default repository to install_required_packages()

### DIFF
--- a/bin/dependencies.R
+++ b/bin/dependencies.R
@@ -1,4 +1,4 @@
-install_required_packages <- function(lib = NULL, repos = getOption("repos")) {
+install_required_packages <- function(lib = NULL, repos = getOption("repos", default = c(CRAN = "https://cran.rstudio.com/"))) {
 
   if (is.null(lib)) {
     lib <- .libPaths()


### PR DESCRIPTION
A lot of people do not have the default repository set in R, so this command fails in Make. Adding a default option fixes the issue.