### PR TITLE
lesson.scss: no borders around unrecognized code

### DIFF
--- a/assets/css/lesson.scss
+++ b/assets/css/lesson.scss
@@ -329,6 +329,12 @@ div.life-cycle {
     background: #d9edf7;
 }
 
+// Remove border around spans of text within code blocks
+// that the highlighter (rouge) failed to recognize.
+pre.highlight span.err {
+    border: none;
+}
+
 
 //----------------------------------------
 // keyboard key style, from StackExchange.


### PR DESCRIPTION
An example showing the border:
![image](https://user-images.githubusercontent.com/13123663/96773108-ac891d80-13a9-11eb-8562-26ee26de16bf.png)

After the change:
![image](https://user-images.githubusercontent.com/13123663/96773211-cf1b3680-13a9-11eb-86c1-b45fbf743c8a.png)

Technically, selectors can be more general (`.highlight .err`) but more specific selectors shouldn't make things worse and might help avoid situations like 61db2b1.