### PR TITLE
proposing a colour swap for hyperlinked text for more contrast

### DIFF
--- a/assets/css/lesson.scss
+++ b/assets/css/lesson.scss
@@ -108,7 +108,7 @@ ul.nav.nav-tabs li a { line-height: 24px; } // or 1.714285716
 // 9.24 on FFFFFF: https://webaim.org/resources/contrastchecker/?fcolor=204A6F&bcolor=FFFFFF&api (body)
 // 8.78 on F9F9F9: https://webaim.org/resources/contrastchecker/?fcolor=204A6F&bcolor=F9F9F9&api (tables)
 // 7.07 on E1E1E1: https://webaim.org/resources/contrastchecker/?fcolor=204A6F&bcolor=E1E1E1&api (tab panels)
-a { color: #204A6F; }
+a { color: #306CA2; }
 
 // .yt-wrapper2 can be used for limiting maximum width of YouTube iframes only
 .yt-wrapper2 { max-width: 100%; margin: 0 auto; }


### PR DESCRIPTION
Because links are not underlined, I would like to propose a change in hyperlink colours so we can have more contrast with surrounding text. WebAIM suggests, that "For usability and accessibility, links should be underlined by default. Otherwise, link text must have at least 3:1 contrast with surrounding body text, and must present a non-color indicator (typically underline) on mouse hover and keyboard focus."

Here's a helpful tool to check for contrast ratios: https://webaim.org/resources/linkcontrastchecker/