### PR TITLE
add class for images with a drop shadow

### DIFF
--- a/assets/css/lesson.scss
+++ b/assets/css/lesson.scss
@@ -302,7 +302,7 @@ span.fold-unfold {
 
 
 img.image-with-shadow {
-  box-shadow: 0 6px 24px 0 rgba(0, 0, 0, 0.25);
+  box-shadow: 0 6px 24px 0 #888;
 }
 
 //----------------------------------------

--- a/assets/css/lesson.scss
+++ b/assets/css/lesson.scss
@@ -302,7 +302,7 @@ span.fold-unfold {
 
 
 img.image-with-shadow {
-  box-shadow: 0 4px 16px 0 rgba(0, 0, 0, 0.2), 0 6px 24px 0 rgba(0, 0, 0, 0.19);
+  box-shadow: 0 6px 24px 0 rgba(0, 0, 0, 0.25);
 }
 
 //----------------------------------------

--- a/assets/css/lesson.scss
+++ b/assets/css/lesson.scss
@@ -301,6 +301,7 @@ span.fold-unfold {
 }
 
 
+p.image-with-shadow img,
 img.image-with-shadow {
   box-shadow: 0 6px 24px 0 #888;
 }

--- a/assets/css/lesson.scss
+++ b/assets/css/lesson.scss
@@ -299,6 +299,10 @@ span.fold-unfold {
 }
 
 
+img.image-with-shadow {
+  box-shadow: 0 4px 16px 0 rgba(0, 0, 0, 0.2), 0 6px 24px 0 rgba(0, 0, 0, 0.19);
+}
+
 //----------------------------------------
 // Life cycle box
 //----------------------------------------


### PR DESCRIPTION
To address the issue described in #513, this introduces a `img.image-with-shadow` class with a drop shadow. If and when this is accepted, I'll document it in the lesson example.