### PR TITLE
Matlab -> MATLAB

### DIFF
--- a/assets/css/lesson.scss
+++ b/assets/css/lesson.scss
@@ -82,7 +82,7 @@ div.language-c::before      { content: "C"; }
 div.language-cmake::before  { content: "CMake"; }
 div.language-cpp::before    { content: "C++"; }
 div.language-make::before   { content: "Make"; }
-div.language-matlab::before { content: "Matlab"; }
+div.language-matlab::before { content: "MATLAB"; }
 div.language-python::before { content: "Python"; }
 div.language-r::before      { content: "R"; }
 div.language-sql::before    { content: "SQL"; }


### PR DESCRIPTION
As @gcapes points out in https://github.com/swcarpentry/matlab-novice-inflammation/pull/230#issuecomment-723922937 `.language-matlab` code blocks should be prefaced with "MATLAB" rather than "Matlab" as they are currently.