### PR TITLE
Don't trim trailing spaces in markdown

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,6 +9,7 @@ trim_trailing_whitespace = true
 indent_size = 2
 indent_style = space
 max_line_length = 100  # Please keep this in sync with bin/lesson_check.py!
+trim_trailing_whitespace = false  # keep trailing spaces in markdown - 2+ spaces are translated to a hard break (<br/>)
 
 [*.r]
 max_line_length = 80


### PR DESCRIPTION
This caused formatting issues when using Theia through Gitpod

More info at:
https://github.com/carpentries-incubator/building-websites-with-jekyll-and-github-or-gitlab/pull/96
https://github.com/gitpod-io/gitpod/issues/896#issuecomment-722853235

Originally submitted at: https://github.com/carpentries/lesson-example/pull/310