### PR TITLE
404 page for better learner experience

### DIFF
--- a/404.md
+++ b/404.md
@@ -1,0 +1,25 @@
+---
+layout: base
+root: .
+permalink: 404.html
+title: "Page not found"
+---
+
+# Oops! We can't find that page.
+{: style="text-align: center;"}
+
+> ## Our apologies!
+>
+> We can't seem to find the page you're looking for.
+> Try going back to the <a href="javascript:history.back()">previous page</a> or
+> navigate to any other page using the navigation bar above
+> {%- if site.kind == "lesson" -%} or the schedule below {%- endif -%}.
+> If you got here by clicking on a link in the
+> {%- if site.kind == "lesson" -%} lesson {%- else -%} workshop {%- endif -%},
+> please report this link to the
+> {%- if site.kind == "lesson" -%} lesson developers {%- else -%} workshop organizers {%- endif -%}.
+{: .caution}
+
+{% if site.kind == "lesson" %}
+  {% include syllabus.html %}
+{% endif%}


### PR DESCRIPTION
A landing page for learners / workshop attendees that click on invalid links or type in web-addresses incorrectly. 
The page works for lessons and workshops.

<details>
<summary><strong>Preview</strong></summary>

![image](https://user-images.githubusercontent.com/13123663/100151478-ce713680-2e66-11eb-9e0d-5ea8ca6b0800.png)

</details>
