### PR TITLE
Gemfile and bin/markdown_ast.rb: fix Ruby style

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source 'https://rubygems.org'
 
-git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 # Synchronize with https://pages.github.com/versions
 ruby '>=2.7.1'

--- a/bin/markdown_ast.rb
+++ b/bin/markdown_ast.rb
@@ -1,11 +1,12 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 # Use Kramdown parser to produce AST for Markdown document.
 
-require "kramdown"
-require "json"
+require 'kramdown'
+require 'json'
 
-markdown = STDIN.read()
+markdown = $stdin.read
 doc = Kramdown::Document.new(markdown)
 tree = doc.to_hash_a_s_t
 puts JSON.pretty_generate(tree)


### PR DESCRIPTION
Fix Ruby style in `Gemfile` and in `bin/markdown_ast.rb`