### PR TITLE
R package installation: set CRAN url if default is "@CRAN@"

### DIFF
--- a/bin/dependencies.R
+++ b/bin/dependencies.R
@@ -9,6 +9,12 @@ install_required_packages <- function(lib = NULL, repos = getOption("repos", def
     c("rprojroot", "desc", "remotes", "renv"),
     rownames(installed.packages(lib.loc = lib))
   )
+  # The default installation of R will have "@CRAN@" as the default repository, which directs contrib.url() to either
+  # force the user to choose a mirror if interactive or fail if not. Since we are not interactve, we need to force the
+  # mirror here.
+  if ("@CRAN@" %in% repos) {
+    repos <- c(CRAN = "https://cran.rstudio.com/")
+  }
 
   install.packages(missing_pkgs, lib = lib, repos = repos)
 


### PR DESCRIPTION
We naïvely assumed that if the user did not set a default repository, that the default would be NULL. This is not the case. The default repository is set to `"@CRAN@"` and is [used by `contrib.url()` to abort if the session is not interactive](https://github.com/wch/r-source/blob/3a380278179be209a96ac509f67edd85e52e0612/src/library/utils/R/packages.R#L837).

If R packages need to be installed, this will check the default repository value and replace it if it's "@CRAN@"

This will fix #526
