### PR TITLE
run R-based lessons in forks

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -5,7 +5,7 @@ on:
   pull_request: []
 jobs:
   build-website:
-    if: !endsWith(github.repository, '/styles')
+    if: ${{ !endsWith(github.repository, '/styles') }}
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -5,7 +5,7 @@ on:
   pull_request: []
 jobs:
   build-website:
-    if: github.repository != 'carpentries/styles' && (github.repository_owner == 'swcarpentry' || github.repository_owner == 'datacarpentry' || github.repository_owner == 'librarycarpentry' || github.repository_owner == 'carpentries')
+    if: !endsWith(github.repository, '/styles')
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
This is a modification for #501

This is a way to prevent this action from building in forks of `carpentries/styles`, but allowing it to be built in forks of other lessons (unless they happen to end with "styles").
