### PR TITLE
accept any base filename for Rmd episodes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ workshop-check :
 .PHONY : lesson-check lesson-md lesson-files lesson-fixme install-rmd-deps
 
 # RMarkdown files
-RMD_SRC = $(wildcard _episodes_rmd/??-*.Rmd)
+RMD_SRC = $(wildcard _episodes_rmd/*.Rmd)
 RMD_DST = $(patsubst _episodes_rmd/%.Rmd,_episodes/%.md,$(RMD_SRC))
 
 # Lesson source files in the order they appear in the navigation menu.


### PR DESCRIPTION
Related to discussion in https://github.com/carpentries/lesson-example/pull/319. 

Since the introduction of `episode_order` it is no longer necessary for Markdown episode files to follow the `\d\d-filename.md` convention. This PR removes the requirement for `.Rmd` files in `_episodes_rmd/` to follow this naming pattern in order to be converted to `.md` in `make lesson-md`. 