### PR TITLE
Ignore .jekyll-metatada

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .ipynb_checkpoints
 .sass-cache
 .jekyll-cache/
+.jekyll-metadata
 __pycache__
 _site
 .Rproj.user


### PR DESCRIPTION
The `.jekyll-metadata` file appears for incremental builds, see [here](https://jekyllrb.com/docs/configuration/incremental-regeneration/), i.e. when running `bundle exec jekyll serve   --incremental`. It's not currently part of the "official" commands in the `Makefile`, but very useful when making a lot of consecutive changes.