### PR TITLE
Speed up builds of R-based lessons

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -7,6 +7,9 @@ jobs:
   build-website:
     if: ${{ !endsWith(github.repository, '/styles') }}
     runs-on: ubuntu-latest
+    env:
+      RSPM: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }} 
     defaults:
       run:
         shell: bash
@@ -45,6 +48,7 @@ jobs:
         uses: r-lib/actions/setup-r@master
         with:
           r-version: 'release'
+          http-user-agent: "R/4.0.0 (ubuntu-16.04) R (4.0.0 x86_64-pc-linux-gnu x86_64 linux-gnu) on GitHub Actions"
 
       - name: Install needed packages
         if: steps.check-rmd.outputs.count != 0

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -8,7 +8,7 @@ jobs:
     if: ${{ !endsWith(github.repository, '/styles') }}
     runs-on: ubuntu-latest
     env:
-      RSPM: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"
+      RSPM: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }} 
     defaults:
       run:
@@ -48,7 +48,6 @@ jobs:
         uses: r-lib/actions/setup-r@master
         with:
           r-version: 'release'
-          http-user-agent: "R/4.0.0 (ubuntu-16.04) R (4.0.0 x86_64-pc-linux-gnu x86_64 linux-gnu) on GitHub Actions"
 
       - name: Install needed packages
         if: steps.check-rmd.outputs.count != 0


### PR DESCRIPTION
R-based lessons might take a while to build because packages need to be compiled from source. RStudio Package Manager has compiled versions of packages for ubuntu distros starting with 16.04: https://packagemanager.rstudio.com/client/#/repos/1/overview

I've added the necessary magic in the actions yaml to make it work.
