### PR TITLE
allow code blocks with any language- class

### DIFF
--- a/bin/lesson_check.py
+++ b/bin/lesson_check.py
@@ -76,17 +76,6 @@ KNOWN_CODEBLOCKS = {
     'error',
     'output',
     'source',
-    'language-bash',
-    'html',
-    'language-c',
-    'language-cmake',
-    'language-cpp',
-    'language-make',
-    'language-matlab',
-    'language-python',
-    'language-r',
-    'language-shell',
-    'language-sql',
     'warning'
 }
 
@@ -395,7 +384,7 @@ class CheckBase:
 
         for node in self.find_all(self.doc, {'type': 'codeblock'}):
             cls = self.get_val(node, 'attr', 'class')
-            self.reporter.check(cls in KNOWN_CODEBLOCKS,
+            self.reporter.check(cls in KNOWN_CODEBLOCKS or cls.startswith('language-'),
                                 (self.filename, self.get_loc(node)),
                                 'Unknown or missing code block type {0}',
                                 cls)


### PR DESCRIPTION
At the moment, `bin/lesson_check.py` raises errors on any lesson using syntax highlighting for code blocks other than R, Python, SQL, HTML, Bash, MATLAB, and Make, which (among other things) means the tests on lines 82 & 84 of `.github/workflows/website.yml` fail for otherwise valid PRs to those lessons. This PR extends the condition used in `check_codeblock_classes` to allow any class beginning `language-`.

This will benefit lessons in the Carpentries Incubator and elsewhere that are using syntax highlighting for other languages.

I concede in advance that there is probably a more appropriate way to make this change in `lesson_check.py` or `util.py` but I'm afraid the engineering of those scripts is a bit beyond my Python capabilities!