### PR TITLE
deploy from "website" action

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       RSPM: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }} 
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     defaults:
       run:
         shell: bash
@@ -82,6 +82,24 @@ jobs:
           done < <(Rscript -e 'cat(remotes::system_requirements("ubuntu", "18.04"), sep = "\n")')
 
       - run: make site
+
+      - name: Setup Git
+        if: ${{ steps.check-rmd.outputs.count != 0 }}
+        run: |
+          git config --local user.email "actions@github.com"
+          git config --local user.name "GitHub Actions"
+          git status
+
+      - name: Push site
+        if: ${{ github.event.push == 'true' && steps.check-rmd.outputs.count != 0 && github.ref == 'refs/head/main' }}
+        run: |
+          git checkout --orphan gh-pages
+          git add .
+          git commit -m "[GitHub Actions] render website"
+          git remote -v
+          git status
+          git push origin gh-pages
+
       - run: make lesson-check
         if: always()
       - run: make lesson-check-all

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -1,7 +1,9 @@
 name: Website
 on:
   push:
-    branches: gh-pages
+    branches:
+      - gh-pages
+      - main
   pull_request: []
 jobs:
   build-website:
@@ -88,17 +90,15 @@ jobs:
         run: |
           git config --local user.email "actions@github.com"
           git config --local user.name "GitHub Actions"
-          git status
+          git checkout --orphan gha-rendering
 
       - name: Push site
-        if: ${{ github.event.push == 'true' && steps.check-rmd.outputs.count != 0 && github.ref == 'refs/head/main' }}
+        if: ${{ github.event.push == 'true' && steps.check-rmd.outputs.count != 0 && github.ref == 'refs/heads/main' }}
         run: |
-          git checkout --orphan gh-pages
-          git add .
+          rm -rf .bundle
+          git add --force .
           git commit -m "[GitHub Actions] render website"
-          git remote -v
-          git status
-          git push origin gh-pages
+          git push --force origin +gha-rendering:gh-pages
 
       - run: make lesson-check
         if: always()

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -83,24 +83,31 @@ jobs:
             eval sudo $cmd
           done < <(Rscript -e 'cat(remotes::system_requirements("ubuntu", "18.04"), sep = "\n")')
 
-      - run: make site
+      - name: Render the markdown and confirm that the site can be built
+        run: make site
 
-      - name: Setup Git
-        if: ${{ steps.check-rmd.outputs.count != 0 }}
+      - name: Checkout github pages
+        if: ${{ github.event_name == 'push' && steps.check-rmd.outputs.count != 0 && github.ref != 'refs/heads/gh-pages'}}
+        uses: actions/checkout@master
+        with:
+          ref: gh-pages
+          path: gh-pages
+
+      - name: Commit and Push
+        if: ${{ github.event_name == 'push' && steps.check-rmd.outputs.count != 0 && github.ref != 'refs/heads/gh-pages'}}
         run: |
+          # copy everything into gh-pages site
+          cp -r `ls -A | grep -v 'gh-pages' | grep -v '.git' | grep -v '.bundle/' | grep -v '_site'` gh-pages
+          # move into gh-pages, add, commit, and push
+          cd gh-pages
+          # setup git
           git config --local user.email "actions@github.com"
           git config --local user.name "GitHub Actions"
-          git checkout --orphan gha-rendering
+          git add -A .
+          git commit --allow-empty -m "[Github Actions] render website (via ${{ github.sha }}"
+          git push origin gh-pages
+          # return
+          cd ..
 
-      - name: Push site
-        if: ${{ github.event.push == 'true' && steps.check-rmd.outputs.count != 0 && github.ref == 'refs/heads/main' }}
-        run: |
-          rm -rf .bundle/ _site/
-          git add --force .
-          git commit -m "[GitHub Actions] render website"
-          git push --force origin +gha-rendering:gh-pages
-
-      - run: make lesson-check
-        if: always()
       - run: make lesson-check-all
         if: always()

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Push site
         if: ${{ github.event.push == 'true' && steps.check-rmd.outputs.count != 0 && github.ref == 'refs/heads/main' }}
         run: |
-          rm -rf .bundle
+          rm -rf .bundle/ _site/
           git add --force .
           git commit -m "[GitHub Actions] render website"
           git push --force origin +gha-rendering:gh-pages


### PR DESCRIPTION
this is an initial attempt to include deployment as part of the GitHub Actions so R-based lessons can use it without having to create a separate one.

One issue is that in my tests, the conditions on line 96 were too strict and the step was always skipped, I haven't figure out why.

This bumps to the limits of my git knowledge but I approached this by creating an orphan branch, building the lesson there, and force pushing this orphan branch to `gh-pages`. Suggestions for a better approach are welcome.

This also assumes that R-based lesson use `main` as their default branch (which is the case for most at the time but not all)

