### PR TITLE
permissive checks for pre-alpha lessons

### DIFF
--- a/bin/lesson_check.py
+++ b/bin/lesson_check.py
@@ -117,7 +117,10 @@ def main():
 
     args = parse_args()
     args.reporter = Reporter()
-    check_config(args.reporter, args.source_dir)
+    life_cycle = check_config(args.reporter, args.source_dir)
+    # pre-alpha lessons should report without error
+    if life_cycle == "pre-alpha":
+        args.permissive = True
     check_source_rmd(args.reporter, args.source_dir, args.parser)
     args.references = read_references(args.reporter, args.reference_path)
 
@@ -194,6 +197,7 @@ def check_config(reporter, source_dir):
         reporter.check(defaults in config.get('defaults', []),
                    'configuration',
                    '"root" not set to "." in configuration')
+    return config['life_cycle']
 
 def check_source_rmd(reporter, source_dir, parser):
     """Check that Rmd episode files include `source: Rmd`"""


### PR DESCRIPTION
Pre-alpha lessons are always in a state of active development, which means that the makefile will report errors that are expected during the development process. This will cause Make to list issues, but not report an error if a lesson is in pre-alpha. 

This will fix #533 