### PR TITLE
bin/lesson_check.py: allow 'caution' blockquote

### DIFF
--- a/bin/lesson_check.py
+++ b/bin/lesson_check.py
@@ -59,6 +59,7 @@ P_INTERNAL_INCLUDE_LINK = re.compile(r'^{% include ([^ ]*) %}$')
 # What kinds of blockquotes are allowed?
 KNOWN_BLOCKQUOTES = {
     'callout',
+    'caution',
     'challenge',
     'checklist',
     'discussion',
@@ -72,6 +73,7 @@ KNOWN_BLOCKQUOTES = {
 }
 
 # What kinds of code fragments are allowed?
+# Below we allow all 'language-*' code blocks
 KNOWN_CODEBLOCKS = {
     'error',
     'output',


### PR DESCRIPTION
Fix for `Unknown or missing blockquote type caution`

CC @zkamvar