### PR TITLE
avoid ansi color characters from being printed

### DIFF
--- a/bin/generate_md_episodes.R
+++ b/bin/generate_md_episodes.R
@@ -1,5 +1,9 @@
 generate_md_episodes <- function() {
 
+  # avoid ansi color characters from being printed in the output
+  op <- options()
+  on.exit(options(op), add = TRUE)
+  options(crayon.enabled = FALSE)
   ## get the Rmd file to process from the command line, and generate the path
   ## for their respective outputs
   args  <- commandArgs(trailingOnly = TRUE)


### PR DESCRIPTION
I noticed recently that tibble outputs were starting to print ANSI color codes to Markdown output: https://github.com/zkamvar/r-socialsci/commit/131141bb8c3ad937be7d2846b5e8cf4eec50fdf3#diff-294600542f0c9ce185cf4e35ff17bfa1ef370765e94ac5f4f67ce0eb8f506a19

This fixes that rendering issue. 