### PR TITLE
pin ubuntu version to 20.04

### DIFF
--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -97,6 +97,7 @@ jobs:
         if: steps.check-rmd.outputs.count != 0
         run: |
           install.packages(c('remotes', 'rprojroot', 'renv', 'desc', 'rmarkdown', 'knitr'))
+          install.packages('stringi', repos = 'https://cloud.r-project.org')
         shell: Rscript {0}
 
       - name: Query dependencies

--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -12,9 +12,9 @@ jobs:
       fail-fast: false
       matrix:
         lesson: [swcarpentry/shell-novice, datacarpentry/r-intro-geospatial, librarycarpentry/lc-git]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-20.04, macos-latest, windows-latest]
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             os-name: Ubuntu
           - os: macos-latest
             os-name: macOS
@@ -30,7 +30,7 @@ jobs:
       run:
         shell: bash # forces 'Git for Windows' on Windows
     env:
-      RSPM: 'https://packagemanager.rstudio.com/cran/__linux__/bionic/latest'
+      RSPM: 'https://packagemanager.rstudio.com/cran/__linux__/focal/latest'
     steps:
       - name: Set up Ruby
         uses: actions/setup-ruby@v1

--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -97,7 +97,6 @@ jobs:
         if: steps.check-rmd.outputs.count != 0
         run: |
           install.packages(c('remotes', 'rprojroot', 'renv', 'desc', 'rmarkdown', 'knitr'))
-          install.packages('stringi', repos = 'https://cloud.r-project.org')
         shell: Rscript {0}
 
       - name: Query dependencies
@@ -128,5 +127,7 @@ jobs:
             eval sudo $cmd
           done < <(Rscript -e 'cat(remotes::system_requirements("ubuntu", "20.04"), sep = "\n")')
 
-      - run: make site
+      - run: |
+          Rscript -e 'install.packages("stringi", repos = "https://cloud.r-project.org")'
+          make site
         working-directory: lesson

--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -118,6 +118,11 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
           restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
 
+      - name: Install stringi from source
+        if: runner.os == 'Linux' && steps.check-rmd.outputs.count != 0
+        run: install.packages('stringi', repos='https://cloud.r-project.org')
+        shell: Rscript {0}
+
       - name: Install system dependencies for R packages
         if: runner.os == 'Linux' && steps.check-rmd.outputs.count != 0
         working-directory: lesson
@@ -127,7 +132,5 @@ jobs:
             eval sudo $cmd
           done < <(Rscript -e 'cat(remotes::system_requirements("ubuntu", "20.04"), sep = "\n")')
 
-      - run: |
-          Rscript -e 'install.packages("stringi", repos = "https://cloud.r-project.org")'
-          make site
+      - run: make site
         working-directory: lesson

--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -125,7 +125,7 @@ jobs:
           while read -r cmd
           do
             eval sudo $cmd
-          done < <(Rscript -e 'cat(remotes::system_requirements("ubuntu", "18.04"), sep = "\n")')
+          done < <(Rscript -e 'cat(remotes::system_requirements("ubuntu", "20.04"), sep = "\n")')
 
       - run: make site
         working-directory: lesson

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -8,9 +8,9 @@ on:
 jobs:
   build-website:
     if: ${{ !endsWith(github.repository, '/styles') }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
-      RSPM: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"
+      RSPM: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     defaults:
       run:

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -81,7 +81,7 @@ jobs:
           while read -r cmd
           do
             eval sudo $cmd
-          done < <(Rscript -e 'cat(remotes::system_requirements("ubuntu", "18.04"), sep = "\n")')
+          done < <(Rscript -e 'cat(remotes::system_requirements("ubuntu", "20.04"), sep = "\n")')
 
       - name: Render the markdown and confirm that the site can be built
         run: make site

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -72,8 +72,8 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
-          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+          key: ${{ matrix.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
+          restore-keys: ${{ matrix.os }}-${{ hashFiles('.github/R-version') }}-1-
 
       - name: Install system dependencies for R packages
         if: steps.check-rmd.outputs.count != 0

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -55,6 +55,7 @@ jobs:
         if: steps.check-rmd.outputs.count != 0
         run: |
           install.packages(c('remotes', 'rprojroot', 'renv', 'desc', 'rmarkdown', 'knitr'))
+          install.packages('stringi', repos = 'https://cloud.r-project.org')
         shell: Rscript {0}
 
       - name: Query dependencies
@@ -72,8 +73,8 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ${{ env.R_LIBS_USER }}
-          key: ${{ matrix.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
-          restore-keys: ${{ matrix.os }}-${{ hashFiles('.github/R-version') }}-1-
+          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
+          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
 
       - name: Install system dependencies for R packages
         if: steps.check-rmd.outputs.count != 0

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -55,7 +55,6 @@ jobs:
         if: steps.check-rmd.outputs.count != 0
         run: |
           install.packages(c('remotes', 'rprojroot', 'renv', 'desc', 'rmarkdown', 'knitr'))
-          install.packages('stringi', repos = 'https://cloud.r-project.org')
         shell: Rscript {0}
 
       - name: Query dependencies


### PR DESCRIPTION
given that GitHub Actions transitions progressively from 18.04 to 20.04 and that we need to know the version nickname to set the RSPM repo correctly, I'd like to propose we pin the ubuntu version to 20.04 and upgrade manually when needed.