### PR TITLE
Fix Kramdown parser crash

### DIFF
--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Install GitHub Pages, Bundler, and kramdown gems
         run: |
-          gem install github-pages bundler kramdown
+          gem install github-pages bundler kramdown kramdown-parser-gfm
 
       - name: Install Python modules
         run: |

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install GitHub Pages, Bundler, and kramdown gems
         run: |
-          gem install github-pages bundler kramdown
+          gem install github-pages bundler kramdown kramdown-parser-gfm
 
       - name: Install Python modules
         run: |

--- a/bin/markdown_ast.rb
+++ b/bin/markdown_ast.rb
@@ -4,9 +4,10 @@
 # Use Kramdown parser to produce AST for Markdown document.
 
 require 'kramdown'
+require 'kramdown-parser-gfm'
 require 'json'
 
 markdown = $stdin.read
-doc = Kramdown::Document.new(markdown)
+doc = Kramdown::Document.new(markdown, input: 'GFM', hard_wrap: false)
 tree = doc.to_hash_a_s_t
 puts JSON.pretty_generate(tree)


### PR DESCRIPTION
... by using GFM (GitHub-flavored Markdown) parser (`kramdown-parser-gfm`)
instead of the default one (`kramdown`).

The default one fails to produce an AST (Abstract Syntax Tree) when
there is no blank line before the line with the opening code fence.

Related:
 - gettalong/kramdown#530
 - Python-Markdown/markdown#807

Fixes: carpentries/styles#543