### PR TITLE
Adds webrick dependency if ruby version less than 3.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,7 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 ruby '>=2.7.1'
 
 gem 'github-pages', group: :jekyll_plugins
+
+if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.0.0')
+    gem 'webrick', '>= 1.6.1'
+end


### PR DESCRIPTION
Discussed in #552. `webrick` is no longer bundled with Ruby as of version 3.0.0 so this PR adds a check to determine which Ruby version is being used and install `webrick` if necessary.

Would you suggest also testing against Ruby 3.0 in the Github Actions?