### PR TITLE
lesson_check.py allow for missing life_cycle

### DIFF
--- a/bin/lesson_check.py
+++ b/bin/lesson_check.py
@@ -188,7 +188,10 @@ def check_config(reporter, source_dir):
         reporter.check(defaults in config.get('defaults', []),
                    'configuration',
                    '"root" not set to "." in configuration')
-    return config['life_cycle']
+    if 'life_cycle' in config:
+        return config['life_cycle']
+    else
+        return None
 
 def check_source_rmd(reporter, source_dir, parser):
     """Check that Rmd episode files include `source: Rmd`"""

--- a/bin/lesson_check.py
+++ b/bin/lesson_check.py
@@ -188,10 +188,9 @@ def check_config(reporter, source_dir):
         reporter.check(defaults in config.get('defaults', []),
                    'configuration',
                    '"root" not set to "." in configuration')
-    if 'life_cycle' in config:
-        return config['life_cycle']
-    else
-        return None
+    if 'life_cycle' not in config:
+        config['life_cycle'] = None
+    return config['life_cycle']
 
 def check_source_rmd(reporter, source_dir, parser):
     """Check that Rmd episode files include `source: Rmd`"""


### PR DESCRIPTION
There was an issue with make lesson-check on the core lessons that didn't have the life_cycle parameter set. This PR fixes the issue by allowing `life_cycle` to be missing in the _config.yaml (which is standard for core lessons).

Notably, this was not caught in our earlier checks because our github workflow only tested if the sites could be built, but never checked their validity. 

This will fix https://github.com/carpentries/styles/issues/556



