### PR TITLE
Add catch for None type code block in lesson_check

### DIFF
--- a/bin/lesson_check.py
+++ b/bin/lesson_check.py
@@ -392,10 +392,14 @@ class CheckBase:
 
         for node in self.find_all(self.doc, {'type': 'codeblock'}):
             cls = self.get_val(node, 'attr', 'class')
-            self.reporter.check(cls in KNOWN_CODEBLOCKS or cls.startswith('language-'),
+            self.reporter.check(cls is not none and (cls in KNOWN_CODEBLOCKS or
+                cls.startswith('language-')),
                                 (self.filename, self.get_loc(node)),
                                 'Unknown or missing code block type {0}',
                                 cls)
+            if not cls is None:
+                print("NOTE: The AST was malformed and needs to be investigated")
+                print(self.filename, self.get_loc(node))
 
     def check_defined_link_references(self):
         """Check that defined links resolve in the file.

--- a/bin/lesson_check.py
+++ b/bin/lesson_check.py
@@ -392,14 +392,11 @@ class CheckBase:
 
         for node in self.find_all(self.doc, {'type': 'codeblock'}):
             cls = self.get_val(node, 'attr', 'class')
-            self.reporter.check(cls is not none and (cls in KNOWN_CODEBLOCKS or
+            self.reporter.check(cls is not None and (cls in KNOWN_CODEBLOCKS or
                 cls.startswith('language-')),
                                 (self.filename, self.get_loc(node)),
                                 'Unknown or missing code block type {0}',
                                 cls)
-            if not cls is None:
-                print("NOTE: The AST was malformed and needs to be investigated")
-                print(self.filename, self.get_loc(node))
 
     def check_defined_link_references(self):
         """Check that defined links resolve in the file.


### PR DESCRIPTION
There are times when the AST is malformed and does not emit a class for
the code element. We do not want the parser to crash when this happens,
but we also want to notify ourselves that the AST is malformed.

This should not result in an error because as we saw in
https://github.com/carpentries/styles/issues/543, the parser itself can
cause these malformations when the lesson itself renders well. Even
though we fixed the previous issue with an updated parser, problems
still persist:
https://github.com/swcarpentry/r-novice-gapminder/pull/696#issuecomment-796265728

I fully admit that this is a kludge.

This will fix #550 
