### PR TITLE
Makefile: fix 'bundle config' command flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 # Settings
 MAKEFILES=Makefile $(wildcard *.mk)
-JEKYLL=bundle config --local set path .vendor/bundle && bundle install && bundle update && bundle exec jekyll
+JEKYLL=bundle config set --local path .vendor/bundle && bundle install && bundle update && bundle exec jekyll
 PARSER=bin/markdown_ast.rb
 DST=_site
 


### PR DESCRIPTION
This PR fixes our Makefile to use the proper order of commands/arguments for the `bundle config` command, which is:

```
bundle config set --local path ...
```
