### PR TITLE
Makefile: better cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,9 @@ clean :
 	@rm -rf ${DST}
 	@rm -rf .sass-cache
 	@rm -rf bin/__pycache__
+	@rm -rf .vendor
+	@rm -rf .bundle
+	@rm -f Gemfile.lock
 	@find . -name .DS_Store -exec rm {} \;
 	@find . -name '*~' -exec rm {} \;
 	@find . -name '*.pyc' -exec rm {} \;


### PR DESCRIPTION
Clean up:

1. `.vendor` directory where Bundler installed all the gems.
2. `.bundle` directory where Bundler stored its settings.
3. `Gemfile.lock` file generated by Bundler.