### PR TITLE
bin/dependencies.R: handle 'no packages were specified' error

### DIFF
--- a/bin/dependencies.R
+++ b/bin/dependencies.R
@@ -5,10 +5,10 @@ install_required_packages <- function(lib = NULL, repos = getOption("repos", def
   }
 
   message("lib paths: ", paste(lib, collapse = ", "))
-  missing_pkgs <- setdiff(
-    c("rprojroot", "desc", "remotes", "renv"),
-    rownames(installed.packages(lib.loc = lib))
-  )
+  required_pkgs <- c("rprojroot", "desc", "remotes", "renv")
+  installed_pkgs <- rownames(installed.packages(lib.loc = lib))
+  missing_pkgs <- setdiff(required_pkgs, installed_pkgs)
+
   # The default installation of R will have "@CRAN@" as the default repository, which directs contrib.url() to either
   # force the user to choose a mirror if interactive or fail if not. Since we are not interactve, we need to force the
   # mirror here.
@@ -16,8 +16,9 @@ install_required_packages <- function(lib = NULL, repos = getOption("repos", def
     repos <- c(CRAN = "https://cran.rstudio.com/")
   }
 
-  install.packages(missing_pkgs, lib = lib, repos = repos)
-
+  if (length(missing_pkgs) != 0) {
+    install.packages(missing_pkgs, lib = lib, repos = repos)
+  }
 }
 
 find_root <- function() {


### PR DESCRIPTION
Fixes the following issue:

```
$ make site
lib paths: /Library/Frameworks/R.framework/Versions/3.5/Resources/library
Error in install.packages(missing_pkgs, lib = lib, repos = repos) :
  no packages were specified
Calls: install_required_packages -> install.packages
Execution halted
make: *** [install-rmd-deps] Error 1
```
