### PR TITLE
Replace relative_root_path with |relative_url or site.baseurl

### DIFF
--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -50,9 +50,9 @@ jobs:
       - name: Install Python modules
         run: |
           if [[ $RUNNER_OS == macOS || $RUNNER_OS == Linux ]]; then
-            python3 -m pip install --upgrade pip setuptools wheel pyyaml==5.3.1 requests
+            python3 -m pip install --upgrade pip setuptools wheel pyyaml==5.3.1 requests lxml
           elif [[ $RUNNER_OS == Windows ]]; then
-            python -m pip install --upgrade pip setuptools wheel pyyaml==5.3.1 requests
+            python -m pip install --upgrade pip setuptools wheel pyyaml==5.3.1 requests lxml
           fi
 
       - name: Checkout the ${{ matrix.lesson }} lesson

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Install Python modules
         run: |
-          python3 -m pip install --upgrade pip setuptools wheel pyyaml==5.3.1 requests
+          python3 -m pip install --upgrade pip setuptools wheel pyyaml==5.3.1 requests lxml
 
       - name: Checkout the lesson
         uses: actions/checkout@master

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ serve : lesson-md
 ## * site             : build website but do not run a server
 site : lesson-md
 	${JEKYLL} build
+	${PYTHON} bin/convert_urls_to_relative.py ${DST}
 
 ## * docker-serve     : use Docker to serve the site
 docker-serve :

--- a/_includes/base_path.html
+++ b/_includes/base_path.html
@@ -9,6 +9,7 @@ This is adapted from: https://ricostacruz.com/til/relative-paths-in-jekyll
   directly
 {% endcomment %}
 
+{% comment %}
 {% assign relative_root_path = '' %}
 
 {% assign last_char = page.url | slice: -1 %}
@@ -25,3 +26,15 @@ This is adapted from: https://ricostacruz.com/til/relative-paths-in-jekyll
 {% elsif depth == 3 %}{% assign relative_root_path = '../..' %}
 {% elsif depth == 4 %}{% assign relative_root_path = '../../..' %}
 {% endif %}
+{% endcomment %}
+
+{% comment %}
+The above code was used to convert links to relative paths
+to allow reading the lesson without an HTTP server
+(through the file:// protocol)
+
+This is now performed by bin/convert_urls_to_relative.py
+so we can rely on site.baseurl for served websites
+{% endcomment %}
+
+{% assign relative_root_path = site.baseurl %}

--- a/bin/convert_urls_to_relative.py
+++ b/bin/convert_urls_to_relative.py
@@ -56,7 +56,9 @@ def main(builddir="."):
                         path += "index.html"
 
                     # if we don't find the file something went wrong
-                    # TODO: Should this be fatal?
+                    # * A typo in the address
+                    # * A reference to a rendered file that wasn't created
+                    # * A path that isn't supposed to refer to a file (e.g. GitHub links)
                     if not os.path.isfile(path):
                         print(
                             "WARNING: attribute ", attrib,
@@ -65,6 +67,8 @@ def main(builddir="."):
                             " of file ", filename,
                             " references a missing file ", path, "",
                             sep="'")
+                        # TODO: For now we leave it unchanged. Should it be fatal instead?
+                        continue
 
                     new_path = os.path.relpath(path, os.path.dirname(filename))
 

--- a/bin/convert_urls_to_relative.py
+++ b/bin/convert_urls_to_relative.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Transforms all absolute links in rendered HTML files produced by jekyll into
+relative links compatible to browsing rendered lessons without a HTTP server.
+"""
+
+import sys
+import os
+try:
+    import lxml.html as html
+except ImportError:
+    print('Unable to import lxml.html module: please install lxml', file=sys.stderr)
+    sys.exit(1)
+
+from glob import glob
+
+
+# tag: url attribute
+TAGS = {
+    "meta": "content",  # we only match 'content' starting with '/'
+    "link": "href",
+    "a": "href",
+    "img": "src",
+    "script": "src",
+}
+
+
+def iter_html(builddir):
+    """Iterate all html files in the build directory"""
+    for filename in glob(os.path.join(builddir, "**/*.html"), recursive=True):
+        yield filename
+
+
+def main(builddir="."):
+    for filename in iter_html(builddir):
+        et = html.parse(filename)
+
+        for tag in et.iter():
+            try:
+                attrib = TAGS[tag.tag]
+            except KeyError:
+                continue
+
+            # Not all tags have the attribute we are looking for
+            if attrib in tag.attrib:
+                path = tag.attrib[attrib]
+
+                # Should match cases when site.baseurl = /
+                if path.startswith("/"):
+                    path = builddir + path
+
+                    # When path is missing a filename, assume index.html
+                    # as would be the case by a HTTP server
+                    if path.endswith("/"):
+                        path += "index.html"
+
+                    # if we don't find the file something went wrong
+                    # TODO: Should this be fatal?
+                    if not os.path.isfile(path):
+                        print(
+                            "WARNING: attribute ", attrib,
+                            " in tag ", tag.tag,
+                            " and line number ", tag.sourceline,
+                            " of file ", filename,
+                            " references a missing file ", path, "",
+                            sep="'")
+
+                    new_path = os.path.relpath(path, os.path.dirname(filename))
+
+                    tag.attrib[attrib] = new_path
+
+        # NOTE: This overwrites the original files
+        et.write(filename, pretty_print=True)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Argument missing, need path to built website")
+        sys.exit(1)
+    main(sys.argv[1])


### PR DESCRIPTION
In order to remove `relative_root_path` two substitutions were performed:

1. `{{ relative_root_path }} some/path` became `{{ 'some/path' | relative_url }}`.
1.1. the special case `{{ relative_root_path }}/` becomes `{{ site.baseurl }}`. 
2. `{{ relative_root_path }}{% link some/resource.md %}` became `{{ site.baseurl }}{% link some/resource.md %}`

The change in 2. will need to be adjusted when migrating to Jekyll 4.0 where `{{ site.baseurl }}` is already included by default with `{% link %}`.

Also removes `_includes/base_path.html` as this file is no longer necessary.

Fixes #568

@tobyhodges 