### PR TITLE
add link references to code_of_conduct.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -8,4 +8,5 @@ we pledge to follow the [Carpentry Code of Conduct][coc].
 Instances of abusive, harassing, or otherwise unacceptable behavior
 may be reported by following our [reporting guidelines][coc-reporting].
 
-{% include links.md %}
+[coc]: https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html
+[coc-reporting]: https://docs.carpentries.org/topic_folders/policies/incident-reporting.html


### PR DESCRIPTION
`CODE_OF_CONDUCT.md` is currently setup for the rendered version of the page on the lesson website, but I believe some potential contributors to lessons will visit the repository and may then be interested in checking the CoC there before they contribute. The current setup of the page, which `include`s the link references from `_includes/links.md` makes it quite difficult to find the URL for the CoC when visiting `CODE_OF_CONDUCT.md` on GitHub.

This PR replaces the `include` with the link references for the Code of Conduct and Reporting Guidelines, so that the link is easily available on both the rendered page and the source file.