### PR TITLE
Template workflow: smarter syncing with the styles repo

### DIFF
--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -77,6 +77,7 @@ jobs:
       - name: Sync lesson with carpentries/styles
         working-directory: lesson
         run: |
+          echo "::group::Fetch Styles"
           if [[ -n "${{ github.event.pull_request.number }}" ]]
           then
             ref="refs/pull/${{ github.event.pull_request.number }}/head"
@@ -89,31 +90,38 @@ jobs:
 
           git remote add styles https://github.com/carpentries/styles.git
           git fetch styles $ref:styles-ref
-
+          echo "::endgroup::"
+          echo "::group::Synchronize Styles"
           # Sync up only if necessary
           if [[ $(git rev-list --count HEAD..styles-ref) != 0 ]]
           then
 
             # The merge command below might fail for lessons that use remote theme
             # https://github.com/carpentries/carpentries-theme
+            echo "Testing merge using recursive strategy, accepting upstream changes without committing"
             if ! git merge -s recursive -Xtheirs --no-commit styles-ref
             then
 
               # Remove "deleted by us, unmerged" files from the staging area.
               # these are the files that were removed from the lesson
               # but are still present in the carpentries/styles repo
+              echo "Removing previously deleted files"
               git rm $(git diff --name-only --diff-filter=DU)
 
               # If there are still "unmerged" files,
               # let's raise an error and look into this more closely
               if [[ -n $(git diff --name-only --diff-filter=U) ]]
               then
+                echo "There were unmerged files in ${{ matrix.lesson-name }}:"
+                echo "$(git diff --compact-summary --diff-filter=U)"
                 exit 1
               fi
             fi
 
+            echo "Committing changes"
             git commit -m "Sync lesson with carpentries/styles"
           fi
+          echo "::endgroup::"
 
       - name: Look for R-markdown files
         id: check-rmd

--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -15,7 +15,6 @@ jobs:
         lesson: [swcarpentry/shell-novice, datacarpentry/r-intro-geospatial, librarycarpentry/lc-git]
         os: [ubuntu-20.04, macos-latest, windows-latest]
         experimental: [false]
-        remote-theme: [false]
         include:
           - os: ubuntu-20.04
             os-name: Linux
@@ -34,7 +33,6 @@ jobs:
             experimental: true
             os: ubuntu-20.04
             os-name: Linux
-            remote-theme: true
           - lesson: carpentries/lesson-example
             lesson-name: (CP) Lesson Example
             experimental: false
@@ -76,26 +74,46 @@ jobs:
           path: lesson
           fetch-depth: 0
 
-      - name: Determine the proper reference to use
-        id: styles-ref
-        run: |
-          if [[ -n "${{ github.event.pull_request.number }}" ]]; then
-            echo "::set-output name=ref::refs/pull/${{ github.event.pull_request.number }}/head"
-          else
-            echo "::set-output name=ref::gh-pages"
-          fi
-
       - name: Sync lesson with carpentries/styles
-        if: ${{ ! matrix.remote-theme }}
         working-directory: lesson
         run: |
+          if [[ -n "${{ github.event.pull_request.number }}" ]]
+          then
+            ref="refs/pull/${{ github.event.pull_request.number }}/head"
+          else
+            ref="gh-pages"
+          fi
+
           git config --global user.email "team@carpentries.org"
           git config --global user.name "The Carpentries Bot"
+
           git remote add styles https://github.com/carpentries/styles.git
-          git config --local remote.styles.tagOpt --no-tags
-          git fetch styles ${{ steps.styles-ref.outputs.ref }}:styles-ref
-          git merge -s recursive -Xtheirs --no-commit styles-ref
-          git commit -m "Sync lesson with carpentries/styles"
+          git fetch styles $ref:styles-ref
+
+          # Sync up only if necessary
+          if [[ $(git rev-list --count HEAD..styles-ref) != 0 ]]
+          then
+
+            # The merge command below might fail for lessons that use remote theme
+            # https://github.com/carpentries/carpentries-theme
+            if ! git merge -s recursive -Xtheirs --no-commit styles-ref
+            then
+
+              # Remove "deleted by us, unmerged" files from the staging area.
+              # these are the files that were removed from the lesson
+              # but are still present in the carpentries/styles repo
+              git rm $(git diff --name-only --diff-filter=DU)
+
+              # If there are still "unmerged" files,
+              # let's raise an error and look into this more closely
+              if [[ -n $(git diff --name-only --diff-filter=U) ]]
+              then
+                exit 1
+              fi
+            fi
+
+            git commit -m "Sync lesson with carpentries/styles"
+          fi
 
       - name: Look for R-markdown files
         id: check-rmd


### PR DESCRIPTION
This PR does two things:

1. Merges the contents of the "Determine the proper reference to use" step into the "Sync lesson with carpentries/styles" step.
2. Fixes the latter step so that it doesn't fail for lessons that have just synced up with the carpentries/styles.