### PR TITLE
Template workflow: add two more lessons

### DIFF
--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -8,14 +8,17 @@ jobs:
     name: ${{ matrix.lesson-name }} (${{ matrix.os-name }})
     if: github.repository == 'carpentries/styles'
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
         lesson: [swcarpentry/shell-novice, datacarpentry/r-intro-geospatial, librarycarpentry/lc-git]
         os: [ubuntu-20.04, macos-latest, windows-latest]
+        experimental: [false]
+        remote-theme: [false]
         include:
           - os: ubuntu-20.04
-            os-name: Ubuntu
+            os-name: Linux
           - os: macos-latest
             os-name: macOS
           - os: windows-latest
@@ -26,6 +29,17 @@ jobs:
             lesson-name: (DC) R Intro Geospatial
           - lesson: librarycarpentry/lc-git
             lesson-name: (LC) Intro to Git
+          - lesson: datacarpentry/astronomy-python
+            lesson-name: (DC) Foundations of Astronomical Data Science
+            experimental: true
+            os: ubuntu-20.04
+            os-name: Linux
+            remote-theme: true
+          - lesson: carpentries/lesson-example
+            lesson-name: (CP) Lesson Example
+            experimental: false
+            os: ubuntu-20.04
+            os-name: Linux
     defaults:
       run:
         shell: bash # forces 'Git for Windows' on Windows
@@ -72,6 +86,7 @@ jobs:
           fi
 
       - name: Sync lesson with carpentries/styles
+        if: ${{ ! matrix.remote-theme }}
         working-directory: lesson
         run: |
           git config --global user.email "team@carpentries.org"

--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -150,4 +150,5 @@ jobs:
           done < <(Rscript -e 'cat(remotes::system_requirements("ubuntu", "20.04"), sep = "\n")')
 
       - run: make site
+      - run: make lesson-check-all
         working-directory: lesson

--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -150,5 +150,7 @@ jobs:
           done < <(Rscript -e 'cat(remotes::system_requirements("ubuntu", "20.04"), sep = "\n")')
 
       - run: make site
+        working-directory: lesson
+
       - run: make lesson-check-all
         working-directory: lesson


### PR DESCRIPTION
I propose to add 2 more lessons to our template-testing matrix: carpentries/lesson-example and datacarpentry/astronomy-python. The first one is probably one of the lessons that the first-time maintainers look at pretty regularly. The latter one uses The Carpentries remote theme, which makes it a unique lesson in the build matrix.