### PR TITLE
bin/lesson_check.py: one more fix for using_remote_theme()

### DIFF
--- a/bin/lesson_check.py
+++ b/bin/lesson_check.py
@@ -500,7 +500,7 @@ class CheckEpisode(CheckBase):
         """Run extra tests."""
 
         super().check()
-        if not using_remote_theme():
+        if not using_remote_theme(args.source_dir):
             self.check_reference_inclusion()
 
     def check_metadata(self):


### PR DESCRIPTION
This PR "fixes" `make lesson-check` that currently fails for datacarpentry/astronomy-python.

