### PR TITLE
Template workflow: Install R packages after restoring cache

### DIFF
--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -109,13 +109,6 @@ jobs:
         with:
           r-version: 'release'
 
-      - name: Install needed packages
-        if: steps.check-rmd.outputs.count != 0
-        run: |
-          packages = setdiff(c('remotes', 'rprojroot', 'renv', 'desc', 'rmarkdown', 'knitr'), rownames(installed.packages()))
-          install.packages(packages, repo="https://cran.rstudio.com/")
-        shell: Rscript {0}
-
       - name: Query dependencies
         if: steps.check-rmd.outputs.count != 0
         working-directory: lesson
@@ -127,13 +120,20 @@ jobs:
           writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
         shell: Rscript {0}
 
-      - name: Cache R packages
+      - name: Restore R package cache
         if: runner.os != 'Windows' && steps.check-rmd.outputs.count != 0
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ${{ env.R_LIBS_USER }}
           key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
           restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+
+      - name: Install needed R packages
+        if: steps.check-rmd.outputs.count != 0
+        run: |
+          packages = setdiff(c('remotes', 'rprojroot', 'renv', 'desc', 'rmarkdown', 'knitr'), rownames(installed.packages()))
+          install.packages(packages, repo="https://cran.rstudio.com/")
+        shell: Rscript {0}
 
       - name: Install stringi from source
         if: runner.os == 'Linux' && steps.check-rmd.outputs.count != 0


### PR DESCRIPTION
To have an effect, the caching step has to preceed the installation step.
Here, I move the step that installs some R packages to after the caching step.
I used [this](https://github.com/r-lib/actions/tree/master/examples#when-should-you-use-it-1) as an example.
