### PR TITLE
lesson_check.py: harden single-line image/link pattern

### DIFF
--- a/bin/lesson_check.py
+++ b/bin/lesson_check.py
@@ -57,7 +57,16 @@ P_INTERNAL_LINK_DEF = re.compile(r'^\[([^\]]+)\]:\s*(.+)')
 P_INTERNAL_INCLUDE_LINK = re.compile(r'^{% include ([^ ]*) %}$')
 
 # Pattern to match image-only and link-only lines
-P_LINK_IMAGE_LINE = re.compile("^[> ]*(!?)\[([^]]+)\][([]([^)]+)[])][ ]*$")
+P_LINK_IMAGE_LINE = re.compile(r'''
+    [> #]*        # any number of '>', '#', and spaces
+    !?            # ! or nothing
+    \[[^]]+\]     # [any text]
+    [([]          # ( or [
+    [^])]+        # 1+ characters that are neither ] nor )
+    [])]          # ] or )
+    (?:{:[^}]+})? # {:any text} or nothing
+    [ ]*          # any number of spaces
+    \\?$          # \ or nothing + end of line''', re.VERBOSE)
 
 # What kinds of blockquotes are allowed?
 KNOWN_BLOCKQUOTES = {


### PR DESCRIPTION
This change hardens the pattern that matches single-line
image or link:

1. It extends the pattern to be matched in a heading
2. It allows the line to contain {: ...} customizations
3. It allows the line to end with \

Fixes carpentries/styles#591