### PR TITLE
lesson_check.py: relax P_LINK_IMAGE_LINE pattern

### DIFF
--- a/bin/lesson_check.py
+++ b/bin/lesson_check.py
@@ -59,12 +59,14 @@ P_INTERNAL_INCLUDE_LINK = re.compile(r'^{% include ([^ ]*) %}$')
 # Pattern to match image-only and link-only lines
 P_LINK_IMAGE_LINE = re.compile(r'''
     [> #]*        # any number of '>', '#', and spaces
+    \W{,3}        # up to 3 non-word characters
     !?            # ! or nothing
     \[[^]]+\]     # [any text]
     [([]          # ( or [
     [^])]+        # 1+ characters that are neither ] nor )
     [])]          # ] or )
     (?:{:[^}]+})? # {:any text} or nothing
+    \W{,3}        # up to 3 non-word characters
     [ ]*          # any number of spaces
     \\?$          # \ or nothing + end of line''', re.VERBOSE)
 


### PR DESCRIPTION
This PR allows up to 3 non-word (`\W` in Python's `re`-speak) characters
in the beginning and end of the pattern that matches links and images.
This is to allow lesson developers place punctuation marks, parentheses,
or other symbols before and after the link or image on the same line in
Markdown.

