### PR TITLE
update R dependency search; Allow Bioconductor packages

### DIFF
--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -157,7 +157,7 @@ jobs:
 
       - name: Restore Package Cache
         if: runner.os != 'Windows' && steps.check-rmd.outputs.count != 0
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ${{ env.R_LIBS_USER }}
           key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}

--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -137,6 +137,7 @@ jobs:
 
       - name: Install needed packages
         if: steps.check-rmd.outputs.count != 0
+        working-directory: lesson
         run: |
           source('bin/dependencies.R')
           install_required_packages()
@@ -154,7 +155,7 @@ jobs:
           writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
         shell: Rscript {0}
 
-      - name: Cache R packages
+      - name: Restore Package Cache
         if: runner.os != 'Windows' && steps.check-rmd.outputs.count != 0
         uses: actions/cache@v1
         with:

--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -138,8 +138,8 @@ jobs:
       - name: Install needed packages
         if: steps.check-rmd.outputs.count != 0
         run: |
-          packages = setdiff(c('remotes', 'rprojroot', 'renv', 'desc', 'rmarkdown', 'knitr'), rownames(installed.packages()))
-          install.packages(packages, repo="https://cran.rstudio.com/")
+          source('bin/dependencies.R')
+          install_required_packages()
         shell: Rscript {0}
 
       - name: Query dependencies
@@ -149,6 +149,7 @@ jobs:
           source('bin/dependencies.R')
           deps <- identify_dependencies()
           create_description(deps)
+          use_bioc_repos()
           saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
           writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
         shell: Rscript {0}

--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -140,7 +140,7 @@ jobs:
         working-directory: lesson
         run: |
           source('bin/dependencies.R')
-          install_required_packages()
+          install_required_packages(.libPaths()[1])
         shell: Rscript {0}
 
       - name: Query dependencies

--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -174,7 +174,7 @@ jobs:
         run: |
           while read -r cmd
           do
-            eval sudo $cmd
+            eval sudo $cmd || echo "Nothing to update"
           done < <(Rscript -e 'cat(remotes::system_requirements("ubuntu", "20.04"), sep = "\n")')
 
       - run: make site

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -84,7 +84,7 @@ jobs:
         run: |
           while read -r cmd
           do
-            eval sudo $cmd
+            eval sudo $cmd || echo "Nothing to update"
           done < <(Rscript -e 'cat(remotes::system_requirements("ubuntu", "20.04"), sep = "\n")')
 
       - name: Render the markdown and confirm that the site can be built

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Restore R Cache
         if: steps.check-rmd.outputs.count != 0
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ${{ env.R_LIBS_USER }}
           key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           r-version: 'release'
 
-      - name: Cache R packages
+      - name: Restore R Cache
         if: steps.check-rmd.outputs.count != 0
         uses: actions/cache@v1
         with:
@@ -63,8 +63,8 @@ jobs:
       - name: Install needed packages
         if: steps.check-rmd.outputs.count != 0
         run: |
-          packages = setdiff(c('remotes', 'rprojroot', 'renv', 'desc', 'rmarkdown', 'knitr'), rownames(installed.packages()))
-          install.packages(packages, repo="https://cran.rstudio.com/")
+          source('bin/dependencies.R')
+          install_required_packages()
         shell: Rscript {0}
 
       - name: Query dependencies
@@ -73,6 +73,7 @@ jobs:
           source('bin/dependencies.R')
           deps <- identify_dependencies()
           create_description(deps)
+          use_bioc_repos()
           saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
           writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
         shell: Rscript {0}

--- a/bin/dependencies.R
+++ b/bin/dependencies.R
@@ -72,7 +72,7 @@ identify_dependencies <- function() {
 
 create_description <- function(required_pkgs) {
   d <- desc::description$new("!new")
-  d$set_deps(data.frame(type = "Imports", package = required_packages, version = "*"))
+  d$set_deps(data.frame(type = "Imports", package = required_pkgs, version = "*"))
   d$write("DESCRIPTION")
   # We have to write the description twice to get the hidden dependencies
   # because renv only considers explicit dependencies.

--- a/bin/dependencies.R
+++ b/bin/dependencies.R
@@ -80,7 +80,7 @@ create_description <- function(required_pkgs) {
   # This is needed because some of the hidden dependencis will require system
   # libraries to be configured.
   suppressMessages(repo <- BiocManager::repositories())
-  deps <- remotes::dev_package_deps(dependencies = TRUE, repos = repo)
+  deps <- remotes::dev_package_deps(dependencies = TRUE, repos = repo)$package
   d$set_deps(data.frame(type = "Imports", package = deps, version = "*"))
   d$write("DESCRIPTION")
 }

--- a/bin/dependencies.R
+++ b/bin/dependencies.R
@@ -84,7 +84,7 @@ create_description <- function(required_pkgs) {
   suppressMessages(repo <- BiocManager::repositories())
   deps <- remotes::dev_package_deps(dependencies = TRUE, repos = repo)
   deps <- deps$package[deps$diff < 0]
-  if (nrow(deps)) {
+  if (length(deps)) {
     # only create new DESCRIPTION file if there are dependencies to install
     d$set_deps(data.frame(type = "Imports", package = deps, version = "*"))
     d$write("DESCRIPTION")

--- a/bin/dependencies.R
+++ b/bin/dependencies.R
@@ -84,8 +84,11 @@ create_description <- function(required_pkgs) {
   suppressMessages(repo <- BiocManager::repositories())
   deps <- remotes::dev_package_deps(dependencies = TRUE, repos = repo)
   deps <- deps$package[deps$diff < 0]
-  d$set_deps(data.frame(type = "Imports", package = deps, version = "*"))
-  d$write("DESCRIPTION")
+  if (nrow(deps)) {
+    # only create new DESCRIPTION file if there are dependencies to install
+    d$set_deps(data.frame(type = "Imports", package = deps, version = "*"))
+    d$write("DESCRIPTION")
+  }
 }
 
 install_dependencies <- function(required_pkgs, ...) {

--- a/bin/dependencies.R
+++ b/bin/dependencies.R
@@ -59,12 +59,14 @@ identify_dependencies <- function() {
 
   reset_repos <- use_bioc_repos()
   on.exit(reset_repos(), add = TRUE)
+  eps <- file.path(root, "_episodes_rmd")
+  bin <- file.path(root, "bin")
 
   required_pkgs <- unique(c(
     ## Packages for episodes
-    renv::dependencies(file.path(root, "_episodes_rmd"), progress = FALSE, error = "ignore")$Package,
+    renv::dependencies(eps, progress = FALSE, error = "ignored")$Package,
     ## Packages for tools
-    renv::dependencies(file.path(root, "bin"), progress = FALSE, error = "ignore")$Package
+    renv::dependencies(bin, progress = FALSE, error = "ignored")$Package
   ))
 
   required_pkgs

--- a/bin/dependencies.R
+++ b/bin/dependencies.R
@@ -82,7 +82,8 @@ create_description <- function(required_pkgs) {
   # This is needed because some of the hidden dependencis will require system
   # libraries to be configured.
   suppressMessages(repo <- BiocManager::repositories())
-  deps <- remotes::dev_package_deps(dependencies = TRUE, repos = repo)$package
+  deps <- remotes::dev_package_deps(dependencies = TRUE, repos = repo)
+  deps <- deps$package[dep$diff < 0]
   d$set_deps(data.frame(type = "Imports", package = deps, version = "*"))
   d$write("DESCRIPTION")
 }

--- a/bin/dependencies.R
+++ b/bin/dependencies.R
@@ -5,7 +5,8 @@ install_required_packages <- function(lib = NULL, repos = getOption("repos", def
   }
 
   message("lib paths: ", paste(lib, collapse = ", "))
-  required_pkgs <- c("rprojroot", "desc", "remotes", "renv", "BiocManager")
+  # Note: RMarkdown is needed for renv to detect packages in Rmd documents.
+  required_pkgs <- c("rprojroot", "desc", "remotes", "renv", "BiocManager", "rmarkdown")
   installed_pkgs <- rownames(installed.packages(lib.loc = lib))
   missing_pkgs <- setdiff(required_pkgs, installed_pkgs)
 

--- a/bin/dependencies.R
+++ b/bin/dependencies.R
@@ -83,7 +83,7 @@ create_description <- function(required_pkgs) {
   # libraries to be configured.
   suppressMessages(repo <- BiocManager::repositories())
   deps <- remotes::dev_package_deps(dependencies = TRUE, repos = repo)
-  deps <- deps$package[dep$diff < 0]
+  deps <- deps$package[deps$diff < 0]
   d$set_deps(data.frame(type = "Imports", package = deps, version = "*"))
   d$write("DESCRIPTION")
 }

--- a/bin/dependencies.R
+++ b/bin/dependencies.R
@@ -1,11 +1,11 @@
 install_required_packages <- function(lib = NULL, repos = getOption("repos", default = c(CRAN = "https://cran.rstudio.com/"))) {
 
   if (is.null(lib)) {
-    lib <- .libPaths()
+    lib <- .libPaths()[[1]]
   }
 
   message("lib paths: ", paste(lib, collapse = ", "))
-  required_pkgs <- c("rprojroot", "desc", "remotes", "renv", "BiocManager", "rmarkdown")
+  required_pkgs <- c("rprojroot", "desc", "remotes", "renv", "BiocManager")
   installed_pkgs <- rownames(installed.packages(lib.loc = lib))
   missing_pkgs <- setdiff(required_pkgs, installed_pkgs)
 

--- a/bin/dependencies.R
+++ b/bin/dependencies.R
@@ -5,13 +5,14 @@ install_required_packages <- function(lib = NULL, repos = getOption("repos", def
   }
 
   message("lib paths: ", paste(lib, collapse = ", "))
-  required_pkgs <- c("rprojroot", "desc", "remotes", "renv", "BiocManager")
+  required_pkgs <- c("rprojroot", "desc", "remotes", "renv", "BiocManager", "rmarkdown")
   installed_pkgs <- rownames(installed.packages(lib.loc = lib))
   missing_pkgs <- setdiff(required_pkgs, installed_pkgs)
 
-  # The default installation of R will have "@CRAN@" as the default repository, which directs contrib.url() to either
-  # force the user to choose a mirror if interactive or fail if not. Since we are not interactve, we need to force the
-  # mirror here.
+  # The default installation of R will have "@CRAN@" as the default repository,
+  # which directs contrib.url() to either force the user to choose a mirror if
+  # interactive or fail if not. Since we are not interactve, we need to force
+  # the mirror here.
   if ("@CRAN@" %in% repos) {
     repos <- c(CRAN = "https://cran.rstudio.com/")
   }


### PR DESCRIPTION
This allows bioconductor packages to be installed and cleans up some of
the steps from the workflows to make them a bit more readable.

A new function is added to bin/dependencies.R called use_bioc_repos() that will
set "repos" option to the ones used by BioConductor and returns a function that
resets it to the user-set repository options.

BiocManager has been added to the default packages added.

One of the things we want to pay attention to: `renv::dependencies()` does not list hidden (recursive) dependencies, so when we create the DESCRIPTION file, I have updated it to create it based on the output of `remotes::dev_package_deps()`, and at that, only the ones that have changed. This way, when we call `remotes::system_requirements()`, it can install the requirements for these dependencies that are not explicitly listed. 
