### PR TITLE
Don't force hostname into relative_root_path

### DIFF
--- a/_includes/base_path.html
+++ b/_includes/base_path.html
@@ -7,7 +7,7 @@ When we start a local server using `jekyll serve`,
 'site.url' is set to 'http://localhost:4000' and
 'site.baseurl' is empty.
 
-In both of the above cases we set 'relative_root_path' to 'site.url + site.baseurl'.
+In both of the above cases we set 'relative_root_path' to 'site.baseurl'.
 
 When we build a website locally with `jekyll build`,
 both 'site.url' and 'site.baseurl' are empty.
@@ -25,7 +25,7 @@ The logic there follows the (adapted) instructions found at:
 {%- endcomment -%}
 
 {% if site.url %}
-  {% assign relative_root_path = site.url | append: site.baseurl %}
+  {% assign relative_root_path = site.baseurl %}
 {% else %}
   {% assign last_char = page.url | slice: -1 %}
   {% if last_char == "/" %}


### PR DESCRIPTION
When using platforms such as https://gitpod.io the content generated via `make serve` has `site.url` set to `http://localhost:4000` but is served via a web proxy with an arbitrary hostname (e.g. `https://4000-ivory-camel-r25nr08e.ws-eu01.gitpod.io`).

The existing code hardcodes the hostname breaking URLs served through said proxy.

I can't think of any use-case that would break if the hostname is absent, so this PR removes `site.url` and uses only `site.baseurl`.
I tested the use-cases described in #569 and #578 and all seems to work as expected.