### PR TITLE
lesson.scss: define 'inline' class for images

### DIFF
--- a/assets/css/lesson.scss
+++ b/assets/css/lesson.scss
@@ -258,6 +258,11 @@ article img {
     max-width: 100%;
 }
 
+article img.inline {
+    display: inline-block;
+    margin: auto;
+}
+
 article h2 {
   margin: 48px 0 16px;
   border-bottom: solid 1px #eaecef;


### PR DESCRIPTION
Define `inline` class for images that should not be displayed as block elements.

By appending `{:class="inline"}` or `{: .inline}` to an image definition in Markdown, one can create an inline image that doesn't break the current line and is embedded in the paragraph. Useful for showing special symbols and hieroglyphs that we can't display by other means.

**Example:**
Lesson: https://github.com/carpentries-incubator/SDC-BIDS-dMRI
Episode: diffusion_tensor_imaging
Diff:
```diff
diff --git a/_episodes/diffusion_tensor_imaging.md b/_episodes/diffusion_tensor_imaging.md
index 32fa976..ca8475d 100644
--- a/_episodes/diffusion_tensor_imaging.md
+++ b/_episodes/diffusion_tensor_imaging.md
@@ -29,14 +29,14 @@ The tensor models the diffusion signal mathematically as:
 
 ![Diffusion signal equation]({{ relative_root_path }}/fig/diffusion_tensor_imaging/diffusion_eqn.png){:class="img-responsive"}
 
-Where ![Diffusion unit vector]({{ relative_root_path }}/fig/diffusion_tensor_imaging/inline_unitvector.png) 
+Where ![Diffusion unit vector]({{ relative_root_path }}/fig/diffusion_tensor_imaging/inline_unitvector.png){:class="inline"}
 is a unit vector in 3D space indicating the direction of measurement and b are the parameters of 
 the measurement, such as the strength and duration of diffusion-weighting gradient. 
-![Diffusion signal]({{ relative_root_path }}/fig/diffusion_tensor_imaging/inline_diffusionsignal.png) 
+![Diffusion signal]({{ relative_root_path }}/fig/diffusion_tensor_imaging/inline_diffusionsignal.png){:class="inline"}
 is the diffusion-weighted signal measured and 
-![Non-weighted diffusion signal]({{ relative_root_path }}/fig/diffusion_tensor_imaging/inline_nondiffsignal.png) 
+![Non-weighted diffusion signal]({{ relative_root_path }}/fig/diffusion_tensor_imaging/inline_nondiffsignal.png){:class="inline"}
 is the signal conducted in a measurement with no diffusion weighting. 
-![Diffusivity]({{ relative_root_path }}/fig/diffusion_tensor_imaging/inline_diffusionmatrix.png) 
+![Diffusivity]({{ relative_root_path }}/fig/diffusion_tensor_imaging/inline_diffusionmatrix.png){: .inline}
 is a positive-definite quadratic form, which contains six free parameters to be fit. 
 These six parameters are:
 
```
Result:

![image](https://user-images.githubusercontent.com/13123663/118877509-250a7b00-b8b4-11eb-8341-1b1759934277.png)

CC @jhlegarreta