### PR TITLE
Makefile: require index.md

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,11 +41,11 @@ endif
 .PHONY: site docker-serve repo-check clean clean-rmd
 
 ## * serve            : render website and run a local server
-serve : lesson-md
+serve : lesson-md index.md
 	${JEKYLL} serve
 
 ## * site             : build website but do not run a server
-site : lesson-md
+site : lesson-md index.md
 	${JEKYLL} build
 
 ## * docker-serve     : use Docker to serve the site
@@ -169,6 +169,13 @@ commands :
 python :
 ifeq (, $(PYTHON))
 	$(error $(PYTHON_NOTE))
+else
+	@:
+endif
+
+index.md :
+ifeq (, $(wildcard index.md))
+	$(error index.md not found)
 else
 	@:
 endif


### PR DESCRIPTION
index.md is required for building websites of The Carpentries' lessons, so this PR adds `index.md` as a new target and makes it a requirement for `site` and `serve` targets.

_Extracted from carpentries/styles#495_

<details><summary><strong>Output before</strong></summary></summary>

```
$ make site
bundle config set --local path .vendor/bundle && bundle install && bundle update && bundle exec jekyll build
Using concurrent-ruby 1.1.9
Using i18n 0.9.5
Using minitest 5.14.4
Using thread_safe 0.3.6
Using tzinfo 1.2.9
Using zeitwerk 2.4.2
Using activesupport 6.0.4
Using public_suffix 4.0.6
Using addressable 2.7.0
Using bundler 2.1.4
Using coffee-script-source 1.11.1
Using execjs 2.8.1
Using coffee-script 2.4.1
Using colorator 1.1.0
Using ruby-enum 0.9.0
Using commonmarker 0.17.13
Using unf_ext 0.0.7.7
Using unf 0.1.4
Using simpleidn 0.2.1
Using dnsruby 1.61.5
Using eventmachine 1.2.7
Using http_parser.rb 0.6.0
Using em-websocket 0.5.2
Using ffi 1.15.3
Using ethon 0.14.0
Using faraday-em_http 1.0.0
Using faraday-em_synchrony 1.0.0
Using faraday-excon 1.1.0
Using faraday-net_http 1.0.1
Using faraday-net_http_persistent 1.1.0
Using multipart-post 2.1.1
Using ruby2_keywords 0.0.4
Using faraday 1.4.2
Using forwardable-extended 2.6.0
Using gemoji 3.0.1
Using sawyer 0.8.2
Using octokit 4.21.0
Using typhoeus 1.4.0
Using github-pages-health-check 1.17.2
Using rb-fsevent 0.11.0
Using rb-inotify 0.10.1
Using sass-listen 4.0.0
Using sass 3.7.4
Using jekyll-sass-converter 1.5.2
Using listen 3.5.1
Using jekyll-watch 2.2.1
Using rexml 3.2.5
Using kramdown 2.3.1
Using liquid 4.0.3
Using mercenary 0.3.6
Using pathutil 0.16.2
Using rouge 3.26.0
Using safe_yaml 1.0.5
Using jekyll 3.9.0
Using jekyll-avatar 0.7.0
Using jekyll-coffeescript 1.1.1
Using jekyll-commonmark 1.3.1
Using jekyll-commonmark-ghpages 0.1.6
Using jekyll-default-layout 0.1.4
Using jekyll-feed 0.15.1
Using jekyll-gist 1.5.0
Using jekyll-github-metadata 2.13.0
Using mini_portile2 2.5.3
Using racc 1.5.2
Using nokogiri 1.11.7 (x86_64-darwin)
Using html-pipeline 2.14.0
Using jekyll-mentions 1.6.0
Using jekyll-optional-front-matter 0.3.2
Using jekyll-paginate 1.1.0
Using jekyll-readme-index 0.3.0
Using jekyll-redirect-from 0.16.0
Using jekyll-relative-links 0.6.1
Using rubyzip 2.3.0
Using jekyll-remote-theme 0.4.3
Using jekyll-seo-tag 2.7.1
Using jekyll-sitemap 1.4.0
Using jekyll-swiss 1.0.0
Using jekyll-theme-architect 0.1.1
Using jekyll-theme-cayman 0.1.1
Using jekyll-theme-dinky 0.1.1
Using jekyll-theme-hacker 0.1.2
Using jekyll-theme-leap-day 0.1.1
Using jekyll-theme-merlot 0.1.1
Using jekyll-theme-midnight 0.1.1
Using jekyll-theme-minimal 0.1.1
Using jekyll-theme-modernist 0.1.1
Using jekyll-theme-primer 0.5.4
Using jekyll-theme-slate 0.1.1
Using jekyll-theme-tactile 0.1.1
Using jekyll-theme-time-machine 0.1.1
Using jekyll-titles-from-headings 0.5.3
Using jemoji 0.12.0
Using kramdown-parser-gfm 1.1.0
Using minima 2.5.1
Using unicode-display_width 1.7.0
Using terminal-table 1.8.0
Using github-pages 215
Bundle complete! 1 Gemfile dependency, 97 gems now installed.
Bundled gems are installed into `./.vendor/bundle`
Fetching gem metadata from https://rubygems.org/...........
Fetching gem metadata from https://rubygems.org/.
Resolving dependencies....
Using concurrent-ruby 1.1.9
Using i18n 0.9.5
Using minitest 5.14.4
Using thread_safe 0.3.6
Using tzinfo 1.2.9
Using zeitwerk 2.4.2
Using activesupport 6.0.4
Using public_suffix 4.0.6
Using addressable 2.7.0
Using bundler 2.1.4
Using coffee-script-source 1.11.1
Using execjs 2.8.1
Using coffee-script 2.4.1
Using colorator 1.1.0
Using ruby-enum 0.9.0
Using commonmarker 0.17.13
Using unf_ext 0.0.7.7
Using unf 0.1.4
Using simpleidn 0.2.1
Fetching dnsruby 1.61.7 (was 1.61.5)
Installing dnsruby 1.61.7 (was 1.61.5)
Using eventmachine 1.2.7
Using http_parser.rb 0.6.0
Using em-websocket 0.5.2
Using ffi 1.15.3
Using ethon 0.14.0
Using faraday-em_http 1.0.0
Using faraday-em_synchrony 1.0.0
Using faraday-excon 1.1.0
Using faraday-net_http 1.0.1
Using faraday-net_http_persistent 1.1.0
Using multipart-post 2.1.1
Using ruby2_keywords 0.0.4
Using faraday 1.4.2
Using forwardable-extended 2.6.0
Using gemoji 3.0.1
Using sawyer 0.8.2
Using octokit 4.21.0
Using typhoeus 1.4.0
Using github-pages-health-check 1.17.2
Using rb-fsevent 0.11.0
Using rb-inotify 0.10.1
Using sass-listen 4.0.0
Using sass 3.7.4
Using jekyll-sass-converter 1.5.2
Using listen 3.5.1
Using jekyll-watch 2.2.1
Using rexml 3.2.5
Using kramdown 2.3.1
Using liquid 4.0.3
Using mercenary 0.3.6
Using pathutil 0.16.2
Using rouge 3.26.0
Using safe_yaml 1.0.5
Using jekyll 3.9.0
Using jekyll-avatar 0.7.0
Using jekyll-coffeescript 1.1.1
Using jekyll-commonmark 1.3.1
Using jekyll-commonmark-ghpages 0.1.6
Using jekyll-default-layout 0.1.4
Using jekyll-feed 0.15.1
Using jekyll-gist 1.5.0
Using jekyll-github-metadata 2.13.0
Using mini_portile2 2.5.3
Using racc 1.5.2
Using nokogiri 1.11.7 (x86_64-darwin)
Using html-pipeline 2.14.0
Using jekyll-mentions 1.6.0
Using jekyll-optional-front-matter 0.3.2
Using jekyll-paginate 1.1.0
Using jekyll-readme-index 0.3.0
Using jekyll-redirect-from 0.16.0
Using jekyll-relative-links 0.6.1
Using rubyzip 2.3.0
Using jekyll-remote-theme 0.4.3
Using jekyll-seo-tag 2.7.1
Using jekyll-sitemap 1.4.0
Using jekyll-swiss 1.0.0
Using jekyll-theme-architect 0.1.1
Using jekyll-theme-cayman 0.1.1
Using jekyll-theme-dinky 0.1.1
Using jekyll-theme-hacker 0.1.2
Using jekyll-theme-leap-day 0.1.1
Using jekyll-theme-merlot 0.1.1
Using jekyll-theme-midnight 0.1.1
Using jekyll-theme-minimal 0.1.1
Using jekyll-theme-modernist 0.1.1
Using jekyll-theme-primer 0.5.4
Using jekyll-theme-slate 0.1.1
Using jekyll-theme-tactile 0.1.1
Using jekyll-theme-time-machine 0.1.1
Using jekyll-titles-from-headings 0.5.3
Using jemoji 0.12.0
Using kramdown-parser-gfm 1.1.0
Using minima 2.5.1
Using unicode-display_width 1.7.0
Using terminal-table 1.8.0
Using github-pages 215
Bundle updated!
Post-install message from dnsruby:
Installing dnsruby...
  For issues and source code: https://github.com/alexdalitz/dnsruby
  For general discussion (please tell us how you use dnsruby): https://groups.google.com/forum/#!forum/dnsruby
Configuration file: /Users/mbelkin/git/swcarpentry/python-novice-inflammation/_config.yml
            Source: /Users/mbelkin/git/swcarpentry/python-novice-inflammation
       Destination: /Users/mbelkin/git/swcarpentry/python-novice-inflammation/_site
 Incremental build: disabled. Enable with --incremental
      Generating... 
  Liquid Exception: Could not find document 'index.md' in tag 'link'. Make sure the document exists and the path is correct. in /Users/mbelkin/git/swcarpentry/python-novice-inflammation/_episodes/01-intro.md
jekyll 3.9.0 | Error:  Could not find document 'index.md' in tag 'link'.

Make sure the document exists and the path is correct.

Traceback (most recent call last):
	63: from /Users/mbelkin/.rbenv/versions/2.7.1/bin/bundle:23:in `<main>'
	62: from /Users/mbelkin/.rbenv/versions/2.7.1/bin/bundle:23:in `load'
	61: from /Users/mbelkin/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/libexec/bundle:34:in `<top (required)>'
	60: from /Users/mbelkin/.rbenv/versions/2.7.1/lib/ruby/2.7.0/bundler/friendly_errors.rb:123:in `with_friendly_errors'
	59: from /Users/mbelkin/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/libexec/bundle:46:in `block in <top (required)>'
	58: from /Users/mbelkin/.rbenv/versions/2.7.1/lib/ruby/2.7.0/bundler/cli.rb:24:in `start'
	57: from /Users/mbelkin/.rbenv/versions/2.7.1/lib/ruby/2.7.0/bundler/vendor/thor/lib/thor/base.rb:476:in `start'
	56: from /Users/mbelkin/.rbenv/versions/2.7.1/lib/ruby/2.7.0/bundler/cli.rb:30:in `dispatch'
	55: from /Users/mbelkin/.rbenv/versions/2.7.1/lib/ruby/2.7.0/bundler/vendor/thor/lib/thor.rb:399:in `dispatch'
	54: from /Users/mbelkin/.rbenv/versions/2.7.1/lib/ruby/2.7.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
	53: from /Users/mbelkin/.rbenv/versions/2.7.1/lib/ruby/2.7.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
	52: from /Users/mbelkin/.rbenv/versions/2.7.1/lib/ruby/2.7.0/bundler/cli.rb:476:in `exec'
	51: from /Users/mbelkin/.rbenv/versions/2.7.1/lib/ruby/2.7.0/bundler/cli/exec.rb:28:in `run'
	50: from /Users/mbelkin/.rbenv/versions/2.7.1/lib/ruby/2.7.0/bundler/cli/exec.rb:63:in `kernel_load'
	49: from /Users/mbelkin/.rbenv/versions/2.7.1/lib/ruby/2.7.0/bundler/cli/exec.rb:63:in `load'
	48: from /Users/mbelkin/git/swcarpentry/python-novice-inflammation/.vendor/bundle/ruby/2.7.0/bin/jekyll:23:in `<top (required)>'
	47: from /Users/mbelkin/git/swcarpentry/python-novice-inflammation/.vendor/bundle/ruby/2.7.0/bin/jekyll:23:in `load'
	46: from /Users/mbelkin/git/swcarpentry/python-novice-inflammation/.vendor/bundle/ruby/2.7.0/gems/jekyll-3.9.0/exe/jekyll:15:in `<top (required)>'
	45: from /Users/mbelkin/git/swcarpentry/python-novice-inflammation/.vendor/bundle/ruby/2.7.0/gems/mercenary-0.3.6/lib/mercenary.rb:19:in `program'
	44: from /Users/mbelkin/git/swcarpentry/python-novice-inflammation/.vendor/bundle/ruby/2.7.0/gems/mercenary-0.3.6/lib/mercenary/program.rb:42:in `go'
	43: from /Users/mbelkin/git/swcarpentry/python-novice-inflammation/.vendor/bundle/ruby/2.7.0/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `execute'
	42: from /Users/mbelkin/git/swcarpentry/python-novice-inflammation/.vendor/bundle/ruby/2.7.0/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `each'
	41: from /Users/mbelkin/git/swcarpentry/python-novice-inflammation/.vendor/bundle/ruby/2.7.0/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `block in execute'
	40: from /Users/mbelkin/git/swcarpentry/python-novice-inflammation/.vendor/bundle/ruby/2.7.0/gems/jekyll-3.9.0/lib/jekyll/commands/build.rb:18:in `block (2 levels) in init_with_program'
	39: from /Users/mbelkin/git/swcarpentry/python-novice-inflammation/.vendor/bundle/ruby/2.7.0/gems/jekyll-3.9.0/lib/jekyll/commands/build.rb:36:in `process'
	38: from /Users/mbelkin/git/swcarpentry/python-novice-inflammation/.vendor/bundle/ruby/2.7.0/gems/jekyll-3.9.0/lib/jekyll/commands/build.rb:65:in `build'
	37: from /Users/mbelkin/git/swcarpentry/python-novice-inflammation/.vendor/bundle/ruby/2.7.0/gems/jekyll-3.9.0/lib/jekyll/command.rb:28:in `process_site'
	36: from /Users/mbelkin/git/swcarpentry/python-novice-inflammation/.vendor/bundle/ruby/2.7.0/gems/jekyll-3.9.0/lib/jekyll/site.rb:71:in `process'
	35: from /Users/mbelkin/git/swcarpentry/python-novice-inflammation/.vendor/bundle/ruby/2.7.0/gems/jekyll-3.9.0/lib/jekyll/site.rb:191:in `render'
	34: from /Users/mbelkin/git/swcarpentry/python-novice-inflammation/.vendor/bundle/ruby/2.7.0/gems/jekyll-3.9.0/lib/jekyll/site.rb:462:in `render_docs'
	33: from /Users/mbelkin/git/swcarpentry/python-novice-inflammation/.vendor/bundle/ruby/2.7.0/gems/jekyll-3.9.0/lib/jekyll/site.rb:462:in `each_value'
	32: from /Users/mbelkin/git/swcarpentry/python-novice-inflammation/.vendor/bundle/ruby/2.7.0/gems/jekyll-3.9.0/lib/jekyll/site.rb:463:in `block in render_docs'
	31: from /Users/mbelkin/git/swcarpentry/python-novice-inflammation/.vendor/bundle/ruby/2.7.0/gems/jekyll-3.9.0/lib/jekyll/site.rb:463:in `each'
	30: from /Users/mbelkin/git/swcarpentry/python-novice-inflammation/.vendor/bundle/ruby/2.7.0/gems/jekyll-3.9.0/lib/jekyll/site.rb:464:in `block (2 levels) in render_docs'
	29: from /Users/mbelkin/git/swcarpentry/python-novice-inflammation/.vendor/bundle/ruby/2.7.0/gems/jekyll-3.9.0/lib/jekyll/site.rb:479:in `render_regenerated'
	28: from /Users/mbelkin/git/swcarpentry/python-novice-inflammation/.vendor/bundle/ruby/2.7.0/gems/jekyll-3.9.0/lib/jekyll/renderer.rb:62:in `run'
	27: from /Users/mbelkin/git/swcarpentry/python-novice-inflammation/.vendor/bundle/ruby/2.7.0/gems/jekyll-3.9.0/lib/jekyll/renderer.rb:79:in `render_document'
	26: from /Users/mbelkin/git/swcarpentry/python-novice-inflammation/.vendor/bundle/ruby/2.7.0/gems/jekyll-3.9.0/lib/jekyll/renderer.rb:126:in `render_liquid'
	25: from /Users/mbelkin/git/swcarpentry/python-novice-inflammation/.vendor/bundle/ruby/2.7.0/gems/jekyll-3.9.0/lib/jekyll/liquid_renderer/file.rb:28:in `render!'
	24: from /Users/mbelkin/git/swcarpentry/python-novice-inflammation/.vendor/bundle/ruby/2.7.0/gems/jekyll-3.9.0/lib/jekyll/liquid_renderer/file.rb:49:in `measure_time'
	23: from /Users/mbelkin/git/swcarpentry/python-novice-inflammation/.vendor/bundle/ruby/2.7.0/gems/jekyll-3.9.0/lib/jekyll/liquid_renderer/file.rb:29:in `block in render!'
	22: from /Users/mbelkin/git/swcarpentry/python-novice-inflammation/.vendor/bundle/ruby/2.7.0/gems/jekyll-3.9.0/lib/jekyll/liquid_renderer/file.rb:42:in `measure_bytes'
	21: from /Users/mbelkin/git/swcarpentry/python-novice-inflammation/.vendor/bundle/ruby/2.7.0/gems/jekyll-3.9.0/lib/jekyll/liquid_renderer/file.rb:30:in `block (2 levels) in render!'
	20: from /Users/mbelkin/git/swcarpentry/python-novice-inflammation/.vendor/bundle/ruby/2.7.0/gems/liquid-4.0.3/lib/liquid/template.rb:220:in `render!'
	19: from /Users/mbelkin/git/swcarpentry/python-novice-inflammation/.vendor/bundle/ruby/2.7.0/gems/liquid-4.0.3/lib/liquid/template.rb:207:in `render'
	18: from /Users/mbelkin/git/swcarpentry/python-novice-inflammation/.vendor/bundle/ruby/2.7.0/gems/liquid-4.0.3/lib/liquid/template.rb:242:in `with_profiling'
	17: from /Users/mbelkin/git/swcarpentry/python-novice-inflammation/.vendor/bundle/ruby/2.7.0/gems/liquid-4.0.3/lib/liquid/template.rb:208:in `block in render'
	16: from /Users/mbelkin/git/swcarpentry/python-novice-inflammation/.vendor/bundle/ruby/2.7.0/gems/liquid-4.0.3/lib/liquid/block_body.rb:91:in `render'
	15: from /Users/mbelkin/git/swcarpentry/python-novice-inflammation/.vendor/bundle/ruby/2.7.0/gems/liquid-4.0.3/lib/liquid/block_body.rb:103:in `render_node_to_output'
	14: from /Users/mbelkin/git/swcarpentry/python-novice-inflammation/.vendor/bundle/ruby/2.7.0/gems/jekyll-3.9.0/lib/jekyll/tags/include.rb:137:in `render'
	13: from /Users/mbelkin/git/swcarpentry/python-novice-inflammation/.vendor/bundle/ruby/2.7.0/gems/liquid-4.0.3/lib/liquid/context.rb:123:in `stack'
	12: from /Users/mbelkin/git/swcarpentry/python-novice-inflammation/.vendor/bundle/ruby/2.7.0/gems/jekyll-3.9.0/lib/jekyll/tags/include.rb:140:in `block in render'
	11: from /Users/mbelkin/git/swcarpentry/python-novice-inflammation/.vendor/bundle/ruby/2.7.0/gems/jekyll-3.9.0/lib/jekyll/liquid_renderer/file.rb:28:in `render!'
	10: from /Users/mbelkin/git/swcarpentry/python-novice-inflammation/.vendor/bundle/ruby/2.7.0/gems/jekyll-3.9.0/lib/jekyll/liquid_renderer/file.rb:49:in `measure_time'
	 9: from /Users/mbelkin/git/swcarpentry/python-novice-inflammation/.vendor/bundle/ruby/2.7.0/gems/jekyll-3.9.0/lib/jekyll/liquid_renderer/file.rb:29:in `block in render!'
	 8: from /Users/mbelkin/git/swcarpentry/python-novice-inflammation/.vendor/bundle/ruby/2.7.0/gems/jekyll-3.9.0/lib/jekyll/liquid_renderer/file.rb:42:in `measure_bytes'
	 7: from /Users/mbelkin/git/swcarpentry/python-novice-inflammation/.vendor/bundle/ruby/2.7.0/gems/jekyll-3.9.0/lib/jekyll/liquid_renderer/file.rb:30:in `block (2 levels) in render!'
	 6: from /Users/mbelkin/git/swcarpentry/python-novice-inflammation/.vendor/bundle/ruby/2.7.0/gems/liquid-4.0.3/lib/liquid/template.rb:220:in `render!'
	 5: from /Users/mbelkin/git/swcarpentry/python-novice-inflammation/.vendor/bundle/ruby/2.7.0/gems/liquid-4.0.3/lib/liquid/template.rb:207:in `render'
	 4: from /Users/mbelkin/git/swcarpentry/python-novice-inflammation/.vendor/bundle/ruby/2.7.0/gems/liquid-4.0.3/lib/liquid/template.rb:242:in `with_profiling'
	 3: from /Users/mbelkin/git/swcarpentry/python-novice-inflammation/.vendor/bundle/ruby/2.7.0/gems/liquid-4.0.3/lib/liquid/template.rb:208:in `block in render'
	 2: from /Users/mbelkin/git/swcarpentry/python-novice-inflammation/.vendor/bundle/ruby/2.7.0/gems/liquid-4.0.3/lib/liquid/block_body.rb:91:in `render'
	 1: from /Users/mbelkin/git/swcarpentry/python-novice-inflammation/.vendor/bundle/ruby/2.7.0/gems/liquid-4.0.3/lib/liquid/block_body.rb:103:in `render_node_to_output'
/Users/mbelkin/git/swcarpentry/python-novice-inflammation/.vendor/bundle/ruby/2.7.0/gems/jekyll-3.9.0/lib/jekyll/tags/link.rb:27:in `render': Could not find document 'index.md' in tag 'link'. (ArgumentError)

Make sure the document exists and the path is correct.
make: *** [site] Error 1
```
</details>

<details>
<summary>
<strong>
Output after
</strong>
</summary>

```
$ make site
Makefile:184: *** index.md not found.  Stop.
```
</details>