### PR TITLE
lesson_check.py: use proper regex for matching episode files

### DIFF
--- a/bin/lesson_check.py
+++ b/bin/lesson_check.py
@@ -533,7 +533,7 @@ class CheckEpisode(CheckBase):
         """Run extra tests."""
 
         super().check()
-        if not using_remote_theme(args.source_dir):
+        if not using_remote_theme(self.args.source_dir):
             self.check_reference_inclusion()
 
     def check_metadata(self):
@@ -601,7 +601,8 @@ CHECKERS = [
     (re.compile(r'README\.md'), CheckNonJekyll),
     (re.compile(r'index\.md'), CheckIndex),
     (re.compile(r'reference\.md'), CheckReference),
-    (re.compile(os.path.join('_episodes', '*\.md')), CheckEpisode),
+    # '.' below is what's passed on the command line via '-s' flag
+    (re.compile(os.path.join('.','_episodes', '[^/]*\.md')), CheckEpisode),
     (re.compile(r'.*\.md'), CheckGeneric)
 ]
 


### PR DESCRIPTION
Currently used regex does not match episode filenames for two reasons:

1. Missing `./` in the beginning of the filenames
2. CHECKERS contain regex-es, not patterns, so `*` is a modifier for the previous character and not 'match-anything' kind of thing.

As a result, all episode files were checked using `CheckGeneric` class and not the `CheckEpisode` one.


Tangentially related to carpentries/styles#611

