### PR TITLE
switch to using typeform for instructor training

### DIFF
--- a/bin/boilerplate/_config.yml
+++ b/bin/boilerplate/_config.yml
@@ -52,10 +52,10 @@ workshop_site: "https://carpentries.github.io/workshop-template"
 cc_by_human: "https://creativecommons.org/licenses/by/4.0/"
 
 # Surveys.
-pre_survey: "https://carpentries.typeform.com/to/wi32rS?slug="
-post_survey: "https://carpentries.typeform.com/to/UgVdRQ?slug="
-instructor_pre_survey: "https://www.surveymonkey.com/r/instructor_training_pre_survey?workshop_id="
-instructor_post_survey: "https://www.surveymonkey.com/r/instructor_training_post_survey?workshop_id="
+pre_survey: "https://carpentries.typeform.com/to/wi32rS#slug="
+post_survey: "https://carpentries.typeform.com/to/UgVdRQ#slug="
+instructor_pre_survey: "https://carpentries.typeform.com/to/QVOarK#slug="
+instructor_post_survey: "https://carpentries.typeform.com/to/cjJ9UP#slug="
 
 # Set to 'true' for instructor training websites only.
 instructor_training: false


### PR DESCRIPTION
and use the `#` to delineate URL parameters in workshop survey URLs