### PR TITLE
Show solution while printing lessons

### DIFF
--- a/assets/css/lesson.scss
+++ b/assets/css/lesson.scss
@@ -389,3 +389,13 @@ kbd {
     white-space: nowrap;
     font-style: normal;
 }
+
+//------------------------------------------
+// Show solution while printing (Ctrl + P)
+// -----------------------------------------
+
+@media print {
+  blockquote.solution > * {
+    display: unset !important;
+  }
+}


### PR DESCRIPTION
Printing to paper or PDF via the browser would invoke the @media print CSS query. It is useful to show all solution while doing so

<details>
<summary><strong>Instructions</strong></summary>

Thanks for contributing! :heart:

If this contribution is for instructor training, please email the link to this contribution to
checkout@carpentries.org so we can record your progress. You've completed your contribution
step for instructor checkout by submitting this contribution!

Keep in mind that **lesson maintainers are volunteers** and it may take them some time to
respond to your contribution. Although not all contributions can be incorporated into the lesson
materials, we appreciate your time and effort to improve the curriculum. If you have any questions
about the lesson maintenance process or would like to volunteer your time as a contribution
reviewer, please contact The Carpentries Team at team@carpentries.org.

You may delete these instructions from your comment.

\- The Carpentries
</details>
