### PR TITLE
block new gem; add default title to reference.md

### DIFF
--- a/bin/boilerplate/_config.yml
+++ b/bin/boilerplate/_config.yml
@@ -72,6 +72,10 @@ collections:
     output: true
     permalink: /:path/index.html
 
+# avoid titles being converted to headings (https://github.com/carpentries/styles/issues/633)
+titles_from_headings:
+  enabled: false
+
 # Set the default layout for things in the episodes collection.
 defaults:
   - values:

--- a/bin/boilerplate/reference.md
+++ b/bin/boilerplate/reference.md
@@ -1,4 +1,5 @@
 ---
+title: "Reference"
 layout: reference
 ---
 


### PR DESCRIPTION
There was an issue where GitHub had adopted the
jekyll-titles-from-headings gem in their builds so that pages without
default titles would have the first heading adopted as the page title.
This commit disables that gem so that unintentional titles do not appear.

This will fix https://github.com/carpentries/styles/issues/633
