### PR TITLE
Use a pixelated img rendering instead of blurred default

### DIFF
--- a/assets/css/lesson.scss
+++ b/assets/css/lesson.scss
@@ -321,6 +321,9 @@ span.fold-unfold {
   opacity: 0.5;
 }
 
+img {
+  image-rendering: pixelated;
+}
 
 p.image-with-shadow img,
 img.image-with-shadow {

--- a/assets/css/lesson.scss
+++ b/assets/css/lesson.scss
@@ -321,6 +321,12 @@ span.fold-unfold {
   opacity: 0.5;
 }
 
+/*
+  Force a pixelated rendering of images when original resolution is bigger than
+  the <img> viewport to avoid a blurring effect that makes it difficult to read the image.
+  This issue affects primarily Chrome based browsers (as of 2021).
+  See https://github.com/carpentries/styles/pull/636 for the original report and related links 
+*/
 img {
   image-rendering: pixelated;
 }


### PR DESCRIPTION
Workaround to a CSS resize blur rendering problem affecting Google Chrome/Chromium
when the resolution of the image is larger than the image view

See https://stackoverflow.com/a/69156216 for discussion and
https://github.com/carpentries-incubator/jekyll-pages-novice/issues/274 where the issue was initially reported.