### PR TITLE
add new steps to transition lessons to Workbench

### DIFF
--- a/_includes/check_transition_variables.html
+++ b/_includes/check_transition_variables.html
@@ -1,0 +1,17 @@
+{% assign date = include.need_transition_date %}
+
+{% unless site.transition_url %}
+<div class="alert alert-danger">
+  you need to specify the variable <code>transition_url</code>
+  in <code>_config.yml</code>.
+</div>
+{% endunless %}
+
+{% if date == "true" %}
+{% unless site.transition_date %}
+<div class="alert alert-danger">
+  you need to specify the variable <code>transition_date</code>
+  in <code>_config.yml</code>.
+</div>
+{% endunless %}
+{% endif %}

--- a/_includes/lesson_footer.html
+++ b/_includes/lesson_footer.html
@@ -28,10 +28,10 @@
 	{% endif %}
     </div>
     <div class="col-md-6 help-links" align="right">
-	{% if page.source %}
-	{% if page.source == "Rmd" %}
+        {% if site.life_cycle contains 'transition_step' %}
+        <a href="{{repo_url}}">Edit on GitHub</a>
+        {% elsif page.source == "Rmd" %}
 	<a href="{{repo_url}}/edit/{{ default_branch }}/{{page.path|replace: "_episodes", "_episodes_rmd" | replace: ".md", ".Rmd"}}" data-checker-ignore>Edit on GitHub</a>
-	{% endif %}
 	{% else %}
 	<a href="{{repo_url}}/edit/{{ default_branch }}/{{page.path}}" data-checker-ignore>Edit on GitHub</a>
 	{% endif %}

--- a/_includes/lesson_footer.html
+++ b/_includes/lesson_footer.html
@@ -28,7 +28,7 @@
 	{% endif %}
     </div>
     <div class="col-md-6 help-links" align="right">
-        {% if site.life_cycle contains 'transition_step' %}
+        {% if site.life_cycle contains 'transition-step' %}
         <a href="{{repo_url}}">Edit on GitHub</a>
         {% elsif page.source == "Rmd" %}
 	<a href="{{repo_url}}/edit/{{ default_branch }}/{{page.path|replace: "_episodes", "_episodes_rmd" | replace: ".md", ".Rmd"}}" data-checker-ignore>Edit on GitHub</a>

--- a/_includes/life_cycle.html
+++ b/_includes/life_cycle.html
@@ -28,7 +28,48 @@
 {% elsif site.life_cycle == "stable" %}
 
 {% comment %}
-We do not do anything special unless this is a Carpentries Lab lesson
+We do not do anything special for lessons in stable
+{% endcomment %}
+
+
+{% comment %}
+Below we cover the 3 phases of lesson transition towards the Carpentries Workbench:
+- transition_step_1 (`transition_url` variable needed): we indicate that there
+is a new version of the lesson that is available for testing, and that it will be deprecated in the future.
+- transition_step_2 (`transition_url` and `transition_date` variables needed): we indicate that a new version of the lesson is avaiable with a deprecation date.
+- transition_step_3 (`transition_url` variable needed): the lesson if fully deprecated, and a redirect is set up to the new URL
+{% endcomment %}
+
+{% elsif site.life_cycle == "transition_step_1" %}
+{% include check_transition_variables.html need_transition_date = 'false' %}
+
+<div class="alert alert-warning life-cycle">
+  A newer version of this lesson is being tested:
+  <a href="{{ site.transition_url }}">{{ site.transition_url }}</a>.
+  This lesson will become deprecated in the near future.
+</div>
+
+{% elsif site.life_cycle == "transition_step_2" %}
+{% include check_transition_variables.html need_transition_date = 'true' %}
+
+<div class="alert alert-danger life-cycle">
+  A newer version of this lesson is available from: <a href="{{ site.transition_url }}">{{ site.transition_url }}</a>.
+  This lesson will become deprecated on {{ site.transition_date }}.
+</div>
+
+{% elsif site.life_cycle == "transition_step_3" %}
+{% include check_transition_variables.html need_transition_date = 'false' %}
+
+<div class="alert alert-danger life-cycle">
+    This lesson is deprecated. A newer version is available from: <a href="{{ site.transition_url }}">{{ site.transition_url }}</a>.
+</div>
+
+{% endif %}
+
+
+
+{% comment %}
+For Carpentries Lab lessons we add a banner about the review status
 {% endcomment %}
 
 {% if site.carpentry == "lab" %}
@@ -42,5 +83,4 @@ We do not do anything special unless this is a Carpentries Lab lesson
     This lesson has passed peer-review! {% if site.doi != "" %}<a href="{{ site.doi }}">See the publication{{ listing }}.</a>{% endif %}
   </div>
 </div>
-{% endif %}
 {% endif %}

--- a/_includes/life_cycle.html
+++ b/_includes/life_cycle.html
@@ -34,13 +34,13 @@ We do not do anything special for lessons in stable
 
 {% comment %}
 Below we cover the 3 phases of lesson transition towards the Carpentries Workbench:
-- transition_step_1 (`transition_url` variable needed): we indicate that there
+- transition-step-1 (`transition_url` variable needed): we indicate that there
 is a new version of the lesson that is available for testing, and that it will be deprecated in the future.
-- transition_step_2 (`transition_url` and `transition_date` variables needed): we indicate that a new version of the lesson is avaiable with a deprecation date.
-- transition_step_3 (`transition_url` variable needed): the lesson if fully deprecated, and a redirect is set up to the new URL
+- transition-step-2 (`transition_url` and `transition_date` variables needed): we indicate that a new version of the lesson is avaiable with a deprecation date.
+- transition-step-3 (`transition_url` variable needed): the lesson if fully deprecated, and a redirect is set up to the new URL
 {% endcomment %}
 
-{% elsif site.life_cycle == "transition_step_1" %}
+{% elsif site.life_cycle == "transition-step-1" %}
 {% include check_transition_variables.html need_transition_date = 'false' %}
 
 <div class="alert alert-warning life-cycle">
@@ -49,7 +49,7 @@ is a new version of the lesson that is available for testing, and that it will b
   This lesson will become deprecated in the near future.
 </div>
 
-{% elsif site.life_cycle == "transition_step_2" %}
+{% elsif site.life_cycle == "transition-step-2" %}
 {% include check_transition_variables.html need_transition_date = 'true' %}
 
 <div class="alert alert-danger life-cycle">
@@ -57,7 +57,7 @@ is a new version of the lesson that is available for testing, and that it will b
   This lesson will become deprecated on {{ site.transition_date }}.
 </div>
 
-{% elsif site.life_cycle == "transition_step_3" %}
+{% elsif site.life_cycle == "transition-step-3" %}
 {% include check_transition_variables.html need_transition_date = 'false' %}
 
 <div class="alert alert-danger life-cycle">

--- a/_includes/life_cycle.html
+++ b/_includes/life_cycle.html
@@ -37,31 +37,35 @@ Below we cover the 3 phases of lesson transition towards the Carpentries Workben
 - transition-step-1 (`transition_url` variable needed): we indicate that there
 is a new version of the lesson that is available for testing, and that it will be deprecated in the future.
 - transition-step-2 (`transition_url` and `transition_date` variables needed): we indicate that a new version of the lesson is avaiable with a deprecation date.
-- transition-step-3 (`transition_url` variable needed): the lesson if fully deprecated, and a redirect is set up to the new URL
+- transition-step-3 (`transition_url` variable needed): the lesson is fully deprecated, and a redirect is set up to the new URL
 {% endcomment %}
 
 {% elsif site.life_cycle == "transition-step-1" %}
 {% include check_transition_variables.html need_transition_date = 'false' %}
 
 <div class="alert alert-warning life-cycle">
-  A newer version of this lesson is being tested:
+  A newer version of this lesson is being tested on The Carpentries Workbench:
   <a href="{{ site.transition_url }}">{{ site.transition_url }}</a>.
-  This lesson will become deprecated in the near future.
+  The Jekyll version of this lesson will become deprecated in the near future.
 </div>
 
 {% elsif site.life_cycle == "transition-step-2" %}
 {% include check_transition_variables.html need_transition_date = 'true' %}
 
 <div class="alert alert-danger life-cycle">
-  A newer version of this lesson is available from: <a href="{{ site.transition_url }}">{{ site.transition_url }}</a>.
-  This lesson will become deprecated on {{ site.transition_date }}.
+  A newer version of this lesson is available from:
+  <a href="{{ site.transition_url }}">{{ site.transition_url }}</a>.
+  The Jekyll version of this lesson will become deprecated on
+  {{ site.transition_date }}.
 </div>
 
 {% elsif site.life_cycle == "transition-step-3" %}
 {% include check_transition_variables.html need_transition_date = 'false' %}
 
 <div class="alert alert-danger life-cycle">
-    This lesson is deprecated. A newer version is available from: <a href="{{ site.transition_url }}">{{ site.transition_url }}</a>.
+  You are veiwing a deprecated version of this lesson. An updated version is
+  available from:
+  <a href="{{ site.transition_url }}">{{ site.transition_url }}</a>.
 </div>
 
 {% endif %}

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -94,12 +94,12 @@
 
 	{% comment %} Always show license. {% endcomment %}
         <li><a href="{{ relative_root_path }}{% link LICENSE.md %}">License</a></li>
-	{% if page.source %}
-	{% if page.source == "Rmd" %}
+        {% if site.life_cycle contains 'transition_step' %}
+        <li><a href="{{repo_url}}">Improve this page <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span></a></li>
+        {% elsif page.source == "Rmd" %}
 	<li><a href="{{repo_url}}/edit/{{ default_branch }}/{{page.path|replace: "_episodes", "_episodes_rmd" | replace: ".md", ".Rmd"}}" data-checker-ignore>Improve this page <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span></a></li>
-	{% endif %}
 	{% else %}
-	<li><a href="{{repo_url}}/edit/{{ default_branch}}/{{page.path}}" data-checker-ignore>Improve this page <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span></a></li>
+	<li><a href="{{repo_url}}/edit/{{ default_branch }}/{{page.path}}" data-checker-ignore>Improve this page <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span></a></li>
 	{% endif %}
       </ul>
       <form class="navbar-form navbar-right" role="search" id="search" onsubmit="google_search(); return false;">

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -94,7 +94,7 @@
 
 	{% comment %} Always show license. {% endcomment %}
         <li><a href="{{ relative_root_path }}{% link LICENSE.md %}">License</a></li>
-        {% if site.life_cycle contains 'transition_step' %}
+        {% if site.life_cycle contains 'transition-step' %}
         <li><a href="{{repo_url}}">Improve this page <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span></a></li>
         {% elsif page.source == "Rmd" %}
 	<li><a href="{{repo_url}}/edit/{{ default_branch }}/{{page.path|replace: "_episodes", "_episodes_rmd" | replace: ".md", ".Rmd"}}" data-checker-ignore>Improve this page <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span></a></li>

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -23,6 +23,10 @@
 
     {% include favicons.html %}
 
+    {% if site.life_cycle == 'transition_step_3' %}
+    <meta http-equiv="refresh" content="0; url={{ site.transition_url }}" />
+    {% endif %}
+
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
     <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
     <!--[if lt IE 9]>
@@ -32,7 +36,7 @@
 
   <title>
   {% if page.title %}{{ page.title }}{% endif %}{% if page.title and site.title %} &ndash; {% endif %}{% if site.title %}{{ site.title }}{% endif %}
-  </title>  
+  </title>
 
   </head>
   <body>

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -23,7 +23,7 @@
 
     {% include favicons.html %}
 
-    {% if site.life_cycle == 'transition_step_3' %}
+    {% if site.life_cycle == 'transition-step-3' %}
     <meta http-equiv="refresh" content="0; url={{ site.transition_url }}" />
     {% endif %}
 

--- a/bin/boilerplate/_config.yml
+++ b/bin/boilerplate/_config.yml
@@ -16,7 +16,23 @@ title: "Lesson Title"
 # Life cycle stage of the lesson
 # See this page for more details: https://cdh.carpentries.org/the-lesson-life-cycle.html
 # Possible values: "pre-alpha", "alpha", "beta", "stable"
+#
+# Lessons that are going through the transition to the
+# Carpentries Workbench will go through 3 steps:
+# 'transition_step_1': notice indicating a new version
+# 'transition_step_2': notice encouraging to use new version
+# 'transition_step_3': notice indicating the lesson is deprecated,
+#                      with automated redirect
 life_cycle: "pre-alpha"
+
+# For lessons in the life stages in 'transition_step_1' or later:
+# - 'transition_url' holds the URL for the version of the lesson that
+#    uses the Workbench (needed for all 3 steps)
+# - 'transition_date' (in yyyy-mm-dd format) is the date when the lesson
+#    will transition to being deprecated. The date only needs to be decided
+#    when the lesson is in 'transition_step_2'.
+transition_url:
+transition_date:
 
 #------------------------------------------------------------
 # Generic settings (should not need to change).

--- a/bin/boilerplate/_config.yml
+++ b/bin/boilerplate/_config.yml
@@ -19,18 +19,18 @@ title: "Lesson Title"
 #
 # Lessons that are going through the transition to the
 # Carpentries Workbench will go through 3 steps:
-# 'transition_step_1': notice indicating a new version
-# 'transition_step_2': notice encouraging to use new version
-# 'transition_step_3': notice indicating the lesson is deprecated,
+# 'transition-step-1': notice indicating a new version
+# 'transition-step-2': notice encouraging to use new version
+# 'transition-step-3': notice indicating the lesson is deprecated,
 #                      with automated redirect
 life_cycle: "pre-alpha"
 
-# For lessons in the life stages in 'transition_step_1' or later:
+# For lessons in the life stages in 'transition-step-1' or later:
 # - 'transition_url' holds the URL for the version of the lesson that
 #    uses the Workbench (needed for all 3 steps)
 # - 'transition_date' (in yyyy-mm-dd format) is the date when the lesson
 #    will transition to being deprecated. The date only needs to be decided
-#    when the lesson is in 'transition_step_2'.
+#    when the lesson is in 'transition-step-2'.
 transition_url:
 transition_date:
 


### PR DESCRIPTION
Things that need attention:

- [x] review the text for the notices during the transition phases
- [x] do we want to add an extra step with no redirect but a notice that indicates that the content is deprecated?

Still needed:

- [ ] a link to a page that describes in more detail the transition of lessons and what the different steps mean we can link to from the transition notices.

Note that the "Edit on GitHub" link is replaced with the repo URL when the lesson is being transitioned.