### PR TITLE
modify transition workflow/variables

### DIFF
--- a/_includes/check_transition_variables.html
+++ b/_includes/check_transition_variables.html
@@ -1,12 +1,5 @@
 {% assign date = include.need_transition_date %}
 
-{% unless site.transition_url %}
-<div class="alert alert-danger">
-  you need to specify the variable <code>transition_url</code>
-  in <code>_config.yml</code>.
-</div>
-{% endunless %}
-
 {% if date == "true" %}
 {% unless site.transition_date_prebeta %}
 <div class="alert alert-danger">

--- a/_includes/check_transition_variables.html
+++ b/_includes/check_transition_variables.html
@@ -8,9 +8,21 @@
 {% endunless %}
 
 {% if date == "true" %}
-{% unless site.transition_date %}
+{% unless site.transition_date_prebeta %}
 <div class="alert alert-danger">
-  you need to specify the variable <code>transition_date</code>
+  you need to specify the variable <code>transition_date_prebeta</code>
+  in <code>_config.yml</code>.
+</div>
+{% endunless %}
+{% unless site.transition_date_beta %}
+<div class="alert alert-danger">
+  you need to specify the variable <code>transition_date_beta</code>
+  in <code>_config.yml</code>.
+</div>
+{% endunless %}
+{% unless site.transition_date_prerelease %}
+<div class="alert alert-danger">
+  you need to specify the variable <code>transition_date_prerelease</code>
   in <code>_config.yml</code>.
 </div>
 {% endunless %}

--- a/_includes/lesson_footer.html
+++ b/_includes/lesson_footer.html
@@ -28,13 +28,13 @@
 	{% endif %}
     </div>
     <div class="col-md-6 help-links" align="right">
-        {% if site.life_cycle contains 'transition-step' %}
-        <a href="{{repo_url}}">Edit on GitHub</a>
-        {% elsif page.source == "Rmd" %}
-	<a href="{{repo_url}}/edit/{{ default_branch }}/{{page.path|replace: "_episodes", "_episodes_rmd" | replace: ".md", ".Rmd"}}" data-checker-ignore>Edit on GitHub</a>
-	{% else %}
-	<a href="{{repo_url}}/edit/{{ default_branch }}/{{page.path}}" data-checker-ignore>Edit on GitHub</a>
-	{% endif %}
+    {% if site.life_cycle == 'transition-step-2' %}
+    <a href="{{repo_url}}">Edit on GitHub</a>
+    {% elsif page.source == "Rmd" %}
+    <a href="{{repo_url}}/edit/{{ default_branch }}/{{page.path|replace: "_episodes", "_episodes_rmd" | replace: ".md", ".Rmd"}}" data-checker-ignore>Edit on GitHub</a>
+    {% else %}
+    <a href="{{repo_url}}/edit/{{ default_branch }}/{{page.path}}" data-checker-ignore>Edit on GitHub</a>
+    {% endif %}
 	/
 	<a href="{{ repo_url }}/blob/{{ source_branch }}/CONTRIBUTING.md" data-checker-ignore>Contributing</a>
 	/

--- a/_includes/life_cycle.html
+++ b/_includes/life_cycle.html
@@ -44,8 +44,8 @@ is a new version of the lesson that is available for testing, and that it will b
 {% include check_transition_variables.html need_transition_date = 'true' %}
 
 <div class="alert alert-warning life-cycle">
-  A snapshot of this lesson from {{ site.transition_date_prebeta }} is being tested on The Carpentries Workbench:
-  <a href="{{ site.transition_url }}">{{ site.transition_url }}</a>.
+  A snapshot of this lesson from {{ site.transition_date_prebeta }} is being tested on
+  <a href='https://carpentries.github.io/workbench'>The Carpentries Workbench</a>: <a href="{{ site.transition_url }}">{{ site.transition_url }}</a>.
   <br>
   <b>The Workbench version of this lesson will become default on {{ site.transition_date_prerelease }}</b>.
   <button type="button" style="border: true; position: absolute; top: 10px; right: 27px; color: #383838;" class="close" data-dismiss="alert" aria-label="Close">
@@ -58,10 +58,10 @@ is a new version of the lesson that is available for testing, and that it will b
 
 <div class="alert alert-danger alert-dismissible life-cycle" role="alert">
   This lesson is a <b>snapshot from {{ site.transition_date_beta }}</b>.
-  A newer version is being tested on The Carpentries Workbench:
+  A newer version is being tested on <a href='https://carpentries.github.io/workbench'>The Carpentries Workbench</a>:
   <a href="{{ site.transition_url }}">{{ site.transition_url }}</a>.
   <br>
-  The Workbench version of this lesson will become default on <b>{{ site.transition_date_prerelease }}</b>.
+  <b>The Workbench version of this lesson will become default on {{ site.transition_date_prerelease }}</b>.
   <button type="button" style="border: true; position: absolute; top: 10px; right: 27px; color: #383838;" class="close" data-dismiss="alert" aria-label="Close">
     <span aria-hidden="true" style='font-size:34pt'>&times;</span>
   </button>

--- a/_includes/life_cycle.html
+++ b/_includes/life_cycle.html
@@ -41,31 +41,30 @@ is a new version of the lesson that is available for testing, and that it will b
 {% endcomment %}
 
 {% elsif site.life_cycle == "transition-step-1" %}
-{% include check_transition_variables.html need_transition_date = 'false' %}
+{% include check_transition_variables.html need_transition_date = 'true' %}
 
 <div class="alert alert-warning life-cycle">
-  A newer version of this lesson is being tested on The Carpentries Workbench:
+  A snapshot of this lesson from {{ site.transition_date_prebeta }} is being tested on The Carpentries Workbench:
   <a href="{{ site.transition_url }}">{{ site.transition_url }}</a>.
-  The Jekyll version of this lesson will become deprecated in the near future.
+  <br>
+  <b>The Workbench version of this lesson will become default on {{ site.transition_date_prerelease }}</b>.
+  <button type="button" style="border: true; position: absolute; top: 10px; right: 27px; color: #383838;" class="close" data-dismiss="alert" aria-label="Close">
+    <span aria-hidden="true" style='font-size:34pt'>&times;</span>
+  </button>
 </div>
 
 {% elsif site.life_cycle == "transition-step-2" %}
 {% include check_transition_variables.html need_transition_date = 'true' %}
 
-<div class="alert alert-danger life-cycle">
-  A newer version of this lesson is available from:
+<div class="alert alert-danger alert-dismissible life-cycle" role="alert">
+  This lesson is a <b>snapshot from {{ site.transition_date_beta }}</b>.
+  A newer version is being tested on The Carpentries Workbench:
   <a href="{{ site.transition_url }}">{{ site.transition_url }}</a>.
-  The Jekyll version of this lesson will become deprecated on
-  {{ site.transition_date }}.
-</div>
-
-{% elsif site.life_cycle == "transition-step-3" %}
-{% include check_transition_variables.html need_transition_date = 'false' %}
-
-<div class="alert alert-danger life-cycle">
-  You are veiwing a deprecated version of this lesson. An updated version is
-  available from:
-  <a href="{{ site.transition_url }}">{{ site.transition_url }}</a>.
+  <br>
+  The Workbench version of this lesson will become default on <b>{{ site.transition_date_prerelease }}</b>.
+  <button type="button" style="border: true; position: absolute; top: 10px; right: 27px; color: #383838;" class="close" data-dismiss="alert" aria-label="Close">
+    <span aria-hidden="true" style='font-size:34pt'>&times;</span>
+  </button>
 </div>
 
 {% endif %}

--- a/_includes/life_cycle.html
+++ b/_includes/life_cycle.html
@@ -33,11 +33,14 @@ We do not do anything special for lessons in stable
 
 
 {% comment %}
-Below we cover the 3 phases of lesson transition towards the Carpentries Workbench:
-- transition-step-1 (`transition_url` variable needed): we indicate that there
-is a new version of the lesson that is available for testing, and that it will be deprecated in the future.
-- transition-step-2 (`transition_url` and `transition_date` variables needed): we indicate that a new version of the lesson is avaiable with a deprecation date.
-- transition-step-3 (`transition_url` variable needed): the lesson is fully deprecated, and a redirect is set up to the new URL
+Below we cover the 2 phases of lesson transition towards the Carpentries Workbench:
+Variables needed:
+  - transition_date_prebeta: the date of the prebeta stage
+  - transition_date_beta: the date of the beta stage
+  - transition_date_prerelease: the date of the prerelease stage
+
+- transition-step-1: We notify that there is a snapshot of the lesson available for testing, and that it will supersede this version.
+- transition-step-2 We indicate that this version of the lesson is a snapshot and a new version of the lesson is avaiable and will supersede this version at a given date.
 {% endcomment %}
 
 {% elsif site.life_cycle == "transition-step-1" %}
@@ -45,7 +48,8 @@ is a new version of the lesson that is available for testing, and that it will b
 
 <div class="alert alert-warning life-cycle">
   A snapshot of this lesson from {{ site.transition_date_prebeta }} is being tested on
-  <a href='https://carpentries.github.io/workbench'>The Carpentries Workbench</a>: <a href="{{ site.transition_url }}">{{ site.transition_url }}</a>.
+  <a href='https://carpentries.github.io/workbench'>The Carpentries Workbench</a>:
+  <a href="https://preview.carpentries.org/{{ repo_name }}">https://preview.carpentries.org/{{ repo_name }}</a>.
   <br>
   <b>The Workbench version of this lesson will become default on {{ site.transition_date_prerelease }}</b>.
   <button type="button" style="border: true; position: absolute; top: 10px; right: 27px; color: #383838;" class="close" data-dismiss="alert" aria-label="Close">
@@ -59,7 +63,7 @@ is a new version of the lesson that is available for testing, and that it will b
 <div class="alert alert-danger alert-dismissible life-cycle" role="alert">
   This lesson is a <b>snapshot from {{ site.transition_date_beta }}</b>.
   A newer version is being tested on <a href='https://carpentries.github.io/workbench'>The Carpentries Workbench</a>:
-  <a href="{{ site.transition_url }}">{{ site.transition_url }}</a>.
+  <a href="https://preview.carpentries.org/{{ repo_name }}">https://preview.carpentries.org/{{ repo_name }}</a>.
   <br>
   <b>The Workbench version of this lesson will become default on {{ site.transition_date_prerelease }}</b>.
   <button type="button" style="border: true; position: absolute; top: 10px; right: 27px; color: #383838;" class="close" data-dismiss="alert" aria-label="Close">

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -94,7 +94,7 @@
 
 	{% comment %} Always show license. {% endcomment %}
         <li><a href="{{ relative_root_path }}{% link LICENSE.md %}">License</a></li>
-        {% if site.life_cycle contains 'transition-step' %}
+        {% if site.life_cycle == 'transition-step-1' %}
         <li><a href="{{repo_url}}">Improve this page <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span></a></li>
         {% elsif page.source == "Rmd" %}
 	<li><a href="{{repo_url}}/edit/{{ default_branch }}/{{page.path|replace: "_episodes", "_episodes_rmd" | replace: ".md", ".Rmd"}}" data-checker-ignore>Improve this page <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span></a></li>

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -23,10 +23,6 @@
 
     {% include favicons.html %}
 
-    {% if site.life_cycle == 'transition-step-3' %}
-    <meta http-equiv="refresh" content="0; url={{ site.transition_url }}" />
-    {% endif %}
-
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
     <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
     <!--[if lt IE 9]>


### PR DESCRIPTION
1. The transtion headers will now have a button that can close them
   (though its not permenent)
2. The third step of the transition will no longer be coded into the
   yaml here because the third step of the transition will use the
   workbench version as the default version. This means that no redirect
   will be needed.
3. All transition dates will be specified
4. Language has been updated to not refer to "Jekyll" as it may not be
   immediately obvious that Jekyll was used to build the site.


Screenshots:

With `transition-step-1`:

![screenshot of warning banner that says there is a snapshot of this lesson being tested on The Carpentries Workbench and that it will transition over in 2023](https://user-images.githubusercontent.com/3639446/194177467-841c0b7c-7ef6-4897-90fa-bdd7fd21edc9.png)

With `transition-step-2`:

![screenshot of danger banner that says this lesson is a snapshot from November and a newer version is being tested on The Carpentries Workbench and that it will transition over in 2023](https://user-images.githubusercontent.com/3639446/194177855-662bf85e-0b4c-4be6-9df0-455dc7126fca.png)




