### PR TITLE
update beta phase target

### DIFF
--- a/_includes/lesson_footer.html
+++ b/_includes/lesson_footer.html
@@ -29,11 +29,14 @@
     </div>
     <div class="col-md-6 help-links" align="right">
     {% if site.life_cycle == 'transition-step-2' %}
-    <a href="{{repo_url}}">Edit on GitHub</a>
-    {% elsif page.source == "Rmd" %}
-    <a href="{{repo_url}}/edit/{{ default_branch }}/{{page.path|replace: "_episodes", "_episodes_rmd" | replace: ".md", ".Rmd"}}" data-checker-ignore>Edit on GitHub</a>
+    {% assign edit_url = "https://carpentries.github.io/workbench/contributor/beta.html?id=" | append: repo_url %}
     {% else %}
-    <a href="{{repo_url}}/edit/{{ default_branch }}/{{page.path}}" data-checker-ignore>Edit on GitHub</a>
+    {% assign edit_url = repo_url %}
+    {% endif %}
+    {% if page.source == "Rmd" %}
+    <a href="{{edit_url}}/edit/{{ default_branch }}/{{page.path|replace: "_episodes", "_episodes_rmd" | replace: ".md", ".Rmd"}}" data-checker-ignore>Edit on GitHub</a>
+    {% else %}
+    <a href="{{edit_url}}/edit/{{ default_branch }}/{{page.path}}" data-checker-ignore>Edit on GitHub</a>
     {% endif %}
 	/
 	<a href="{{ repo_url }}/blob/{{ source_branch }}/CONTRIBUTING.md" data-checker-ignore>Contributing</a>

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -94,12 +94,16 @@
 
 	{% comment %} Always show license. {% endcomment %}
         <li><a href="{{ relative_root_path }}{% link LICENSE.md %}">License</a></li>
-        {% if site.life_cycle == 'transition-step-1' %}
-        <li><a href="{{repo_url}}">Improve this page <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span></a></li>
-        {% elsif page.source == "Rmd" %}
-	<li><a href="{{repo_url}}/edit/{{ default_branch }}/{{page.path|replace: "_episodes", "_episodes_rmd" | replace: ".md", ".Rmd"}}" data-checker-ignore>Improve this page <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span></a></li>
+        {% if site.life_cycle == 'transition-step-2' %}
+        {% assign edit_url = "https://carpentries.github.io/workbench/contributor/beta.html?id=" | append: repo_url %}
+        {% else %}
+        {% assign edit_url = repo_url %}
+        {% endif %}
+
+        {% if page.source == "Rmd" %}
+	<li><a href="{{edit_url}}/edit/{{ default_branch }}/{{page.path|replace: "_episodes", "_episodes_rmd" | replace: ".md", ".Rmd"}}" data-checker-ignore>Improve this page <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span></a></li>
 	{% else %}
-	<li><a href="{{repo_url}}/edit/{{ default_branch }}/{{page.path}}" data-checker-ignore>Improve this page <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span></a></li>
+	<li><a href="{{edit_url}}/edit/{{ default_branch }}/{{page.path}}" data-checker-ignore>Improve this page <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span></a></li>
 	{% endif %}
       </ul>
       <form class="navbar-form navbar-right" role="search" id="search" onsubmit="google_search(); return false;">


### PR DESCRIPTION
This udpates the beta phase target such that it will redirect users to https://carpentries.github.io/workbench/beta.html, which will take the original URL as an `id` parameter, bringing the user to a page that will explain the beta phase and present them with a link to edit the live lesson. 

This addresses https://github.com/carpentries/workbench/discussions/30
